### PR TITLE
Add cache for NBNco queries

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -173,7 +173,8 @@ def get_all_addresses(suburb: str, state: str) -> list:
 
     # TODO Each thread that accesses a cache should also call close on the cache.
     DISK_CACHE.close()
-    print(DISK_CACHE.stats())
+    hits, misses = DISK_CACHE.stats(reset=True)
+    logging.info('Cache stats: %d hits, %d misses', hits, misses)
 
     return addresses
 

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -1,2 +1,3 @@
 psycopg2
 requests
+diskcache


### PR DESCRIPTION
Per https://github.com/LukePrior/nbn-upgrade-map/issues/36

Add optional (default disabled) HTTP cache.
Split NBN access into separate functions.
Log exceptions that happen in the pooled executor.