### PR TITLE
Return the NBN locID for the provided address, following the addressSplitDetails if required.

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -16,7 +16,7 @@ from nbn import NBNApi
 def augment_address_with_nbn_data(nbn: NBNApi, address: dict):
     """Fetch the upgrade+tech details for the provided address from the NBN API and add to the address dict."""
     try:
-        loc_id = nbn.get_nbn_loc_id(address["gnaf_pid"], address["name"])
+        loc_id = nbn.extended_get_nbn_loc_id(address["gnaf_pid"], address["name"])
         status = nbn.get_nbn_loc_details(loc_id)
         address["locID"] = loc_id
         address["tech"] = status["addressDetail"]["techType"]

--- a/code/nbn.py
+++ b/code/nbn.py
@@ -35,6 +35,16 @@ class NBNApi:
         self.cache[key] = loc_id  # cache indefinitely
         return loc_id
 
+    def extended_get_nbn_loc_id(self, key: str, address: str) -> str:
+        """Return the NBN locID for the provided address, following the addressSplitDetails if required."""
+        loc_id = self.get_nbn_loc_id(key, address)
+        if not loc_id.startswith("LOC"):
+            details = self.get_nbn_loc_details(loc_id)
+            new_address = ' '.join(details['addressSplitDetails'].values())
+            if new_address.lower() != address.lower():
+                loc_id = self.get_nbn_loc_id("X" + key, new_address)
+        return loc_id
+
     def get_nbn_loc_details(self, id: str) -> dict:
         """Return the NBN details for the provided id, or None if there was an error."""
         if id in self.cache:


### PR DESCRIPTION
This resolves 61% of the outstanding LocID in Somerville, VIC:
- 5967 total addresses
- 5019 resolved by first lookup (leaving 948)
- 578 resolved by second lookup (leaving 370)

YMMV