### PR TITLE
Feature/add generated dates

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -6,6 +6,7 @@ import logging
 import os
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 from threading import Lock
 
 import requests
@@ -94,6 +95,7 @@ def format_addresses(addresses: list) -> dict:
     """Convert the list of addresses (with upgrade+tech fields) into a GeoJSON FeatureCollection."""
     formatted_addresses = {
         "type": "FeatureCollection",
+        "generated": datetime.now().isoformat(),
         "features": []
     }
     for address in addresses:

--- a/code/results.py
+++ b/code/results.py
@@ -1,7 +1,7 @@
-import datetime
 import glob
 import json
 import os
+from datetime import datetime
 
 if __name__ == "__main__":
     # check the folders in results
@@ -11,12 +11,21 @@ if __name__ == "__main__":
     for state in states:
         for file in glob.glob(f"results/{state}/*.geojson"):
             filename, _ = os.path.splitext(os.path.basename(file))
+            with open(file, "r", encoding="utf-8") as infile:
+                result = json.load(infile)
+
+            # fixup any missing generated dates
+            if "generated" not in result:
+                result["generated"] = datetime.now().isoformat()
+                with open(file, "w", encoding="utf-8") as outfile:
+                    json.dump(result, outfile)
+
             suburbs.append({
                 "internal": filename.replace("-", " ").upper(),
                 "state": state,
                 "name": filename.replace("-", " ").title(),
                 "file": filename,
-                "date": datetime.datetime.fromtimestamp(os.path.getmtime(file)).strftime("%d-%m-%Y"),
+                "date": datetime.fromisoformat(result["generated"]).strftime("%d-%m-%Y"),
             })
 
     # sort by state + name


### PR DESCRIPTION
Include generated-date in output files. Use this date when generating results.json
(also includes on-the-fly fixup for generated files that don't include this date)