### PR TITLE
Reprocess Glenwood, NSW

### DIFF
--- a/results/NSW/glenwood.geojson
+++ b/results/NSW/glenwood.geojson
@@ -1,6 +1,6 @@
 {
  "type": "FeatureCollection",
- "generated": "2023-05-30T13:15:25.626760",
+ "generated": "2023-06-02T13:37:32.344908",
  "features": [
   {
    "type": "Feature",
@@ -15,7 +15,7 @@
     "name": "1 ABDALE CRESCENT GLENWOOD 2768",
     "locID": "LOC000034593149",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31,7 +31,7 @@
     "name": "1 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000015976062",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47,7 +47,7 @@
     "name": "1 AGINCOURT PLACE GLENWOOD 2768",
     "locID": "LOC000025547022",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63,7 +63,7 @@
     "name": "1 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000103544523",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79,7 +79,7 @@
     "name": "1 ALMONA STREET GLENWOOD 2768",
     "locID": "LOC000015865275",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -95,7 +95,7 @@
     "name": "1 ALPINE WAY GLENWOOD 2768",
     "locID": "LOC000031341175",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -111,7 +111,7 @@
     "name": "1 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000103043434",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -143,7 +143,7 @@
     "name": "1 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000030346803",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -175,7 +175,7 @@
     "name": "1 ARNIKA COURT GLENWOOD 2768",
     "locID": "LOC000153913538",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -223,7 +223,7 @@
     "name": "1 AVRIL COURT GLENWOOD 2768",
     "locID": "LOC000030395577",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -255,7 +255,7 @@
     "name": "1 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000023708770",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -271,7 +271,7 @@
     "name": "1 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000086266078",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -287,7 +287,7 @@
     "name": "1 BETH WAY GLENWOOD 2768",
     "locID": "LOC000018749613",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -319,7 +319,7 @@
     "name": "1 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000054900502",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -335,7 +335,7 @@
     "name": "1 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000102842329",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -351,7 +351,7 @@
     "name": "1 BRONTE AVENUE GLENWOOD 2768",
     "locID": "LOC000034486389",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -367,7 +367,7 @@
     "name": "1 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000039730653",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -383,7 +383,7 @@
     "name": "1 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000061380785",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -415,7 +415,7 @@
     "name": "1 CAROONA WAY GLENWOOD 2768",
     "locID": "LOC000063831846",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -431,7 +431,7 @@
     "name": "1 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000061492021",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -447,7 +447,7 @@
     "name": "1 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000017190869",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -527,7 +527,7 @@
     "name": "1 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000049360249",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -543,7 +543,7 @@
     "name": "1 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000064575880",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -559,7 +559,7 @@
     "name": "1 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000099155338",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -591,7 +591,7 @@
     "name": "1 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000011793100",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -607,7 +607,7 @@
     "name": "1 DARREN COURT GLENWOOD 2768",
     "locID": "LOC000058872525",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -623,7 +623,7 @@
     "name": "1 DENMAN COURT GLENWOOD 2768",
     "locID": "LOC000011341706",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -639,7 +639,7 @@
     "name": "1 DIENELT CLOSE GLENWOOD 2768",
     "locID": "LOC000026238359",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -655,7 +655,7 @@
     "name": "1 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000086916373",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -735,7 +735,7 @@
     "name": "1 EUREKA GROVE GLENWOOD 2768",
     "locID": "LOC000094044113",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -751,7 +751,7 @@
     "name": "1 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000039968767",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -783,7 +783,7 @@
     "name": "1 FIG TERRACE GLENWOOD 2768",
     "locID": "LOC000033912397",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -815,7 +815,7 @@
     "name": "1 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000042376496",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -831,7 +831,7 @@
     "name": "1 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000054660946",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -847,7 +847,7 @@
     "name": "1 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000048553231",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -895,7 +895,7 @@
     "name": "1 GLENLEA COURT GLENWOOD 2768",
     "locID": "LOC000101000568",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -927,7 +927,7 @@
     "name": "1 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000021310230",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -975,7 +975,7 @@
     "name": "1 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000069847596",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -991,7 +991,7 @@
     "name": "1 HAMBRO AVENUE GLENWOOD 2768",
     "locID": "LOC000054993181",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1007,7 +1007,7 @@
     "name": "1 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000043435301",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1039,7 +1039,7 @@
     "name": "1 HONEYEATER TERRACE GLENWOOD 2768",
     "locID": "LOC000079000847",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1055,7 +1055,7 @@
     "name": "1 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000103551298",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1071,7 +1071,7 @@
     "name": "1 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121986861",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1103,7 +1103,7 @@
     "name": "1 KANDOS STREET GLENWOOD 2768",
     "locID": "LOC000086633618",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1119,7 +1119,7 @@
     "name": "1 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000017934759",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1151,7 +1151,7 @@
     "name": "1 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000078758977",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1199,7 +1199,7 @@
     "name": "1 KOOKABURRA GROVE GLENWOOD 2768",
     "locID": "LOC000057623743",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1231,7 +1231,7 @@
     "name": "1 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000043962683",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1247,7 +1247,7 @@
     "name": "1 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000011265558",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1263,7 +1263,7 @@
     "name": "1 LEMON GROVE GLENWOOD 2768",
     "locID": "LOC000068383564",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1277,7 +1277,7 @@
    },
    "properties": {
     "name": "1 LORD WAY GLENWOOD 2768",
-    "locID": "LOC000057904896",
+    "locID": "LOC000046203189",
     "tech": "FTTN",
     "upgrade": "FTTP_NA"
    }
@@ -1295,7 +1295,7 @@
     "name": "1 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000084195285",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1311,7 +1311,7 @@
     "name": "1 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000042852728",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1343,7 +1343,7 @@
     "name": "1 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000095946060",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1359,7 +1359,7 @@
     "name": "1 MARS WAY GLENWOOD 2768",
     "locID": "LOC000042879608",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1375,7 +1375,7 @@
     "name": "1 MATARA WAY GLENWOOD 2768",
     "locID": "LOC000105623748",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1391,7 +1391,7 @@
     "name": "1 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000038331659",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1423,7 +1423,7 @@
     "name": "1 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000094683182",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1439,7 +1439,7 @@
     "name": "1 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000058952739",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1455,7 +1455,7 @@
     "name": "1 MINUET COURT GLENWOOD 2768",
     "locID": "LOC000106057222",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1503,7 +1503,7 @@
     "name": "1 MUSCAT GROVE GLENWOOD 2768",
     "locID": "LOC000082340215",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1519,7 +1519,7 @@
     "name": "1 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000092042888",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1535,7 +1535,7 @@
     "name": "1 NESH PLACE GLENWOOD 2768",
     "locID": "LOC000122030861",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1551,7 +1551,7 @@
     "name": "1 NEWNES CLOSE GLENWOOD 2768",
     "locID": "LOC000001374035",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1567,7 +1567,7 @@
     "name": "1 NIXON STREET GLENWOOD 2768",
     "locID": "LOC000030982864",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1583,7 +1583,7 @@
     "name": "1 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000042898565",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1599,7 +1599,7 @@
     "name": "1 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000020603316",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1615,7 +1615,7 @@
     "name": "1 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000067674999",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1631,7 +1631,7 @@
     "name": "1 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000089181789",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1647,7 +1647,7 @@
     "name": "1 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000030040682",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1663,7 +1663,7 @@
     "name": "1 PEACH GARDENS GLENWOOD 2768",
     "locID": "LOC000081778927",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1679,7 +1679,7 @@
     "name": "1 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000004035163",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1711,7 +1711,7 @@
     "name": "1 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000041199220",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1759,7 +1759,7 @@
     "name": "1 PINNACLE WAY GLENWOOD 2768",
     "locID": "LOC000027334978",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1775,7 +1775,7 @@
     "name": "1 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000098875576",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1791,7 +1791,7 @@
     "name": "1 POPPY WAY GLENWOOD 2768",
     "locID": "LOC000122030874",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1807,7 +1807,7 @@
     "name": "1 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000033414816",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1823,7 +1823,7 @@
     "name": "1 RAYWOOD COURT GLENWOOD 2768",
     "locID": "LOC000101346222",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1839,7 +1839,7 @@
     "name": "1 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000043856967",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1869,9 +1869,9 @@
    },
    "properties": {
     "name": "1 ROSELEA STREET GLENWOOD 2768",
-    "locID": "LOC000114308659",
+    "locID": "LOC000113311361",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1887,7 +1887,7 @@
     "name": "1 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000013025824",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1903,7 +1903,7 @@
     "name": "1 RYDER STREET GLENWOOD 2768",
     "locID": "LOC000059762306",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1951,7 +1951,7 @@
     "name": "1 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000009249094",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1967,7 +1967,7 @@
     "name": "1 SENTINEL STREET GLENWOOD 2768",
     "locID": "LOC000068668322",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1983,7 +1983,7 @@
     "name": "1 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000022230157",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -1999,7 +1999,7 @@
     "name": "1 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000013842735",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2047,7 +2047,7 @@
     "name": "1 SOLAR PLACE GLENWOOD 2768",
     "locID": "LOC000108173381",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2063,7 +2063,7 @@
     "name": "1 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000077001270",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2079,7 +2079,7 @@
     "name": "1 SULTANA GROVE GLENWOOD 2768",
     "locID": "LOC000053059017",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2095,7 +2095,7 @@
     "name": "1 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000082053783",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2111,7 +2111,7 @@
     "name": "1 SWANSEA COURT GLENWOOD 2768",
     "locID": "LOC000114643227",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2143,7 +2143,7 @@
     "name": "1 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000017531700",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2159,7 +2159,7 @@
     "name": "1 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000018110783",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2191,7 +2191,7 @@
     "name": "1 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000090225615",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2207,7 +2207,7 @@
     "name": "1 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000113090559",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2223,7 +2223,7 @@
     "name": "1 WALTHAM WAY GLENWOOD 2768",
     "locID": "LOC000110123371",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2239,7 +2239,7 @@
     "name": "1 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000012203274",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2255,7 +2255,7 @@
     "name": "1 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000012967192",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2287,7 +2287,7 @@
     "name": "1 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000057167550",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2303,7 +2303,7 @@
     "name": "1 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000104966604",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2319,7 +2319,7 @@
     "name": "1 WILLOWLEAF CLOSE GLENWOOD 2768",
     "locID": "LOC000078710839",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2335,7 +2335,7 @@
     "name": "1 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000016801555",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2351,7 +2351,7 @@
     "name": "1 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000096567056",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2399,7 +2399,7 @@
     "name": "1 ZENITH COURT GLENWOOD 2768",
     "locID": "LOC000091191952",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2415,7 +2415,7 @@
     "name": "1-3 RYDER STREET GLENWOOD 2768",
     "locID": "LOC000059762306",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2431,7 +2431,7 @@
     "name": "10 ABDALE CRESCENT GLENWOOD 2768",
     "locID": "LOC000078577426",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2447,7 +2447,7 @@
     "name": "10 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000044413392",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2463,7 +2463,7 @@
     "name": "10 AGINCOURT PLACE GLENWOOD 2768",
     "locID": "LOC000004172838",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2479,7 +2479,7 @@
     "name": "10 ALI PLACE GLENWOOD 2768",
     "locID": "LOC000097533400",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2495,7 +2495,7 @@
     "name": "10 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000078598538",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2511,7 +2511,7 @@
     "name": "10 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000043003693",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2527,7 +2527,7 @@
     "name": "10 AMUET PLACE GLENWOOD 2768",
     "locID": "LOC000003234655",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2559,7 +2559,7 @@
     "name": "10 ANGEL COURT GLENWOOD 2768",
     "locID": "LOC000043225831",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2575,7 +2575,7 @@
     "name": "10 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000014858352",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2607,7 +2607,7 @@
     "name": "10 ARNIKA COURT GLENWOOD 2768",
     "locID": "LOC000121986755",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2639,7 +2639,7 @@
     "name": "10 ARROWSMITH STREET GLENWOOD 2768",
     "locID": "LOC000045940447",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2655,7 +2655,7 @@
     "name": "10 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000064808739",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2703,7 +2703,7 @@
     "name": "10 BEAUMONT AVENUE GLENWOOD 2768",
     "locID": "LOC000101384202",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2719,7 +2719,7 @@
     "name": "10 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000014854983",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2735,7 +2735,7 @@
     "name": "10 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000051381195",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2751,7 +2751,7 @@
     "name": "10 BETH WAY GLENWOOD 2768",
     "locID": "LOC000017161341",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2783,7 +2783,7 @@
     "name": "10 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000042191265",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2799,7 +2799,7 @@
     "name": "10 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000029726626",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2831,7 +2831,7 @@
     "name": "10 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000048628581",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2847,7 +2847,7 @@
     "name": "10 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916181",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2863,7 +2863,7 @@
     "name": "10 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000069166301",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2879,7 +2879,7 @@
     "name": "10 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000076661851",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2895,7 +2895,7 @@
     "name": "10 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000098477759",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2911,7 +2911,7 @@
     "name": "10 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000075355528",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2943,7 +2943,7 @@
     "name": "10 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000063973630",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -2959,7 +2959,7 @@
     "name": "10 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000007423157",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3007,7 +3007,7 @@
     "name": "10 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000102486576",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3023,7 +3023,7 @@
     "name": "10 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000037334024",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3071,7 +3071,7 @@
     "name": "10 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000006504574",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3087,7 +3087,7 @@
     "name": "10 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000057912203",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3103,7 +3103,7 @@
     "name": "10 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000009829283",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3135,7 +3135,7 @@
     "name": "10 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000012332328",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3151,7 +3151,7 @@
     "name": "10 DARREN COURT GLENWOOD 2768",
     "locID": "LOC000018837379",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3167,7 +3167,7 @@
     "name": "10 DEAKIN AVENUE GLENWOOD 2768",
     "locID": "LOC000011394654",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3183,7 +3183,7 @@
     "name": "10 DENMAN COURT GLENWOOD 2768",
     "locID": "LOC000071516318",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3199,7 +3199,7 @@
     "name": "10 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000041080991",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3215,7 +3215,7 @@
     "name": "10 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000034651663",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3247,7 +3247,7 @@
     "name": "10 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000088844922",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3263,7 +3263,7 @@
     "name": "10 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000084243291",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3295,7 +3295,7 @@
     "name": "10 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000099135634",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3327,7 +3327,7 @@
     "name": "10 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000084869095",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3343,7 +3343,7 @@
     "name": "10 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000006274806",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3391,7 +3391,7 @@
     "name": "10 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000042485371",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3407,7 +3407,7 @@
     "name": "10 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000106179448",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3423,7 +3423,7 @@
     "name": "10 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000065205096",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3455,7 +3455,7 @@
     "name": "10 GLENLEA COURT GLENWOOD 2768",
     "locID": "LOC000022217714",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3487,7 +3487,7 @@
     "name": "10 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000028789312",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3503,7 +3503,7 @@
     "name": "10 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000031297096",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3519,7 +3519,7 @@
     "name": "10 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000042881475",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3567,7 +3567,7 @@
     "name": "10 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000081423298",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3583,7 +3583,7 @@
     "name": "10 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000032945620",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3599,7 +3599,7 @@
     "name": "10 HERITAGE PLACE GLENWOOD 2768",
     "locID": "LOC000069687798",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3615,7 +3615,7 @@
     "name": "10 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000108645782",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3647,7 +3647,7 @@
     "name": "10 HOYA WAY GLENWOOD 2768",
     "locID": "LOC000121986764",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3663,7 +3663,7 @@
     "name": "10 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000032188897",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3679,7 +3679,7 @@
     "name": "10 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000048488354",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3695,7 +3695,7 @@
     "name": "10 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121986772",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3727,7 +3727,7 @@
     "name": "10 JOYCE STREET GLENWOOD 2768",
     "locID": "LOC000086579015",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3775,7 +3775,7 @@
     "name": "10 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000006403870",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3791,7 +3791,7 @@
     "name": "10 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000062936284",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3807,7 +3807,7 @@
     "name": "10 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000032241548",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3823,7 +3823,7 @@
     "name": "10 KOOKABURRA GROVE GLENWOOD 2768",
     "locID": "LOC000057623743",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3839,7 +3839,7 @@
     "name": "10 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000055636184",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3855,7 +3855,7 @@
     "name": "10 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000057012581",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3903,7 +3903,7 @@
     "name": "10 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000005444442",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3919,7 +3919,7 @@
     "name": "10 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000042871606",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3935,7 +3935,7 @@
     "name": "10 MAGPIE COURT GLENWOOD 2768",
     "locID": "LOC000121986786",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3967,7 +3967,7 @@
     "name": "10 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000032621258",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3983,7 +3983,7 @@
     "name": "10 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000067436026",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -3999,7 +3999,7 @@
     "name": "10 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000099920235",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4015,7 +4015,7 @@
     "name": "10 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000011361819",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4047,7 +4047,7 @@
     "name": "10 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000047225354",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4063,7 +4063,7 @@
     "name": "10 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000027261213",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4079,7 +4079,7 @@
     "name": "10 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000021374851",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4095,7 +4095,7 @@
     "name": "10 MINUET COURT GLENWOOD 2768",
     "locID": "LOC000096920327",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4111,7 +4111,7 @@
     "name": "10 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000023307332",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4127,7 +4127,7 @@
     "name": "10 NEWNES CLOSE GLENWOOD 2768",
     "locID": "LOC000055513359",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4143,7 +4143,7 @@
     "name": "10 NIXON STREET GLENWOOD 2768",
     "locID": "LOC000085473240",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4159,7 +4159,7 @@
     "name": "10 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000014711969",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4175,7 +4175,7 @@
     "name": "10 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000094404292",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4191,7 +4191,7 @@
     "name": "10 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000057402052",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4207,7 +4207,7 @@
     "name": "10 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000011338151",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4223,7 +4223,7 @@
     "name": "10 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000013050641",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4239,7 +4239,7 @@
     "name": "10 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000073231480",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4255,7 +4255,7 @@
     "name": "10 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000089764729",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4271,7 +4271,7 @@
     "name": "10 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000006455262",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4303,7 +4303,7 @@
     "name": "10 PERIDOT PLACE GLENWOOD 2768",
     "locID": "LOC000085652156",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4319,7 +4319,7 @@
     "name": "10 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000037365562",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4367,7 +4367,7 @@
     "name": "10 PINNACLE WAY GLENWOOD 2768",
     "locID": "LOC000004158515",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4383,7 +4383,7 @@
     "name": "10 PLUM GARDENS GLENWOOD 2768",
     "locID": "LOC000023833139",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4399,7 +4399,7 @@
     "name": "10 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000004567609",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4415,7 +4415,7 @@
     "name": "10 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000072489065",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4431,7 +4431,7 @@
     "name": "10 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000088549748",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4447,7 +4447,7 @@
     "name": "10 RAYWOOD COURT GLENWOOD 2768",
     "locID": "LOC000101346222",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4463,7 +4463,7 @@
     "name": "10 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000100076133",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4495,7 +4495,7 @@
     "name": "10 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000114632396",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4527,7 +4527,7 @@
     "name": "10 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000002246433",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4591,7 +4591,7 @@
     "name": "10 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000038469180",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4607,7 +4607,7 @@
     "name": "10 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000092334896",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4623,7 +4623,7 @@
     "name": "10 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000042110381",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4671,7 +4671,7 @@
     "name": "10 SOLAR PLACE GLENWOOD 2768",
     "locID": "LOC000072873494",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4687,7 +4687,7 @@
     "name": "10 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000038006131",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4703,7 +4703,7 @@
     "name": "10 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000036528630",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4719,7 +4719,7 @@
     "name": "10 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000046158083",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4751,7 +4751,7 @@
     "name": "10 STRAWBERRY WAY GLENWOOD 2768",
     "locID": "LOC000072159219",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4767,7 +4767,7 @@
     "name": "10 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000107089866",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4783,7 +4783,7 @@
     "name": "10 SWANSEA COURT GLENWOOD 2768",
     "locID": "LOC000114852418",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4815,7 +4815,7 @@
     "name": "10 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000108342328",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4831,7 +4831,7 @@
     "name": "10 TAWNY CLOSE GLENWOOD 2768",
     "locID": "LOC000099868615",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4847,7 +4847,7 @@
     "name": "10 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000062946806",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4879,7 +4879,7 @@
     "name": "10 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000061900639",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4895,7 +4895,7 @@
     "name": "10 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000051506380",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4927,7 +4927,7 @@
     "name": "10 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000019822513",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4943,7 +4943,7 @@
     "name": "10 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000063422499",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4959,7 +4959,7 @@
     "name": "10 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000037393619",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4975,7 +4975,7 @@
     "name": "10 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000054924315",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -4991,7 +4991,7 @@
     "name": "10 WILLOWLEAF CLOSE GLENWOOD 2768",
     "locID": "LOC000004091218",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5007,7 +5007,7 @@
     "name": "10 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000090222416",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5023,7 +5023,7 @@
     "name": "100 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000153925060",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5039,7 +5039,7 @@
     "name": "100 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000052806510",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5071,7 +5071,7 @@
     "name": "100 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000064410464",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5087,7 +5087,7 @@
     "name": "1000 OLD WINDSOR ROAD GLENWOOD 2768",
     "locID": "LOC000032256140",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5119,7 +5119,7 @@
     "name": "100A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000029085773",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5135,7 +5135,7 @@
     "name": "100B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000028789312",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5151,7 +5151,7 @@
     "name": "101 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000082229670",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5167,7 +5167,7 @@
     "name": "101 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000074657228",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5183,7 +5183,7 @@
     "name": "101A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000074445237",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5199,7 +5199,7 @@
     "name": "102 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000028873927",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5231,7 +5231,7 @@
     "name": "102 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000076384058",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5247,7 +5247,7 @@
     "name": "103 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000024846535",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5263,7 +5263,7 @@
     "name": "103 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000072165993",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5279,7 +5279,7 @@
     "name": "104 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000040928828",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5311,7 +5311,7 @@
     "name": "104 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000018821496",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5327,7 +5327,7 @@
     "name": "105 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000016254961",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5343,7 +5343,7 @@
     "name": "105 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000019712789",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5359,7 +5359,7 @@
     "name": "106 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000093942907",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5391,7 +5391,7 @@
     "name": "106 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000088588542",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5407,7 +5407,7 @@
     "name": "107 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000089244438",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5423,7 +5423,7 @@
     "name": "107 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000099254779",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5455,7 +5455,7 @@
     "name": "108 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000109603736",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5487,7 +5487,7 @@
     "name": "108 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000052694604",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5503,7 +5503,7 @@
     "name": "108A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000025599069",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5519,7 +5519,7 @@
     "name": "108B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000025334268",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5535,7 +5535,7 @@
     "name": "109 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000028904213",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5551,7 +5551,7 @@
     "name": "109 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000022401676",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5567,7 +5567,7 @@
     "name": "10A ANGEL COURT GLENWOOD 2768",
     "locID": "LOC000153911897",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5615,7 +5615,7 @@
     "name": "10A WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000062783182",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5631,7 +5631,7 @@
     "name": "10B WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000063422499",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5647,7 +5647,7 @@
     "name": "11 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000096367998",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5663,7 +5663,7 @@
     "name": "11 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000071794484",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5679,7 +5679,7 @@
     "name": "11 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000065317728",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5695,7 +5695,7 @@
     "name": "11 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000043506539",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5727,7 +5727,7 @@
     "name": "11 ANGEL COURT GLENWOOD 2768",
     "locID": "LOC000031006352",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5743,7 +5743,7 @@
     "name": "11 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000092364046",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5759,7 +5759,7 @@
     "name": "11 ANITA STREET GLENWOOD 2768",
     "locID": "LOC000062186287",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5823,7 +5823,7 @@
     "name": "11 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000021505504",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5855,7 +5855,7 @@
     "name": "11 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000003792470",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5871,7 +5871,7 @@
     "name": "11 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000054976650",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5903,7 +5903,7 @@
     "name": "11 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000109967791",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5919,7 +5919,7 @@
     "name": "11 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000042659375",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5951,7 +5951,7 @@
     "name": "11 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000042625156",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5967,7 +5967,7 @@
     "name": "11 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916199",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5983,7 +5983,7 @@
     "name": "11 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000010050460",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -5999,7 +5999,7 @@
     "name": "11 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000003139246",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6015,7 +6015,7 @@
     "name": "11 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000011333907",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6031,7 +6031,7 @@
     "name": "11 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000095753910",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6047,7 +6047,7 @@
     "name": "11 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000018880195",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6063,7 +6063,7 @@
     "name": "11 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000077608334",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6079,7 +6079,7 @@
     "name": "11 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000026433753",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6127,7 +6127,7 @@
     "name": "11 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000021320718",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6175,7 +6175,7 @@
     "name": "11 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000009164893",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6191,7 +6191,7 @@
     "name": "11 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000056166963",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6207,7 +6207,7 @@
     "name": "11 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000099096715",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6239,7 +6239,7 @@
     "name": "11 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000078507247",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6255,7 +6255,7 @@
     "name": "11 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000094156508",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6271,7 +6271,7 @@
     "name": "11 EAGLE WAY GLENWOOD 2768",
     "locID": "LOC000055929228",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6303,7 +6303,7 @@
     "name": "11 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000019725456",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6319,7 +6319,7 @@
     "name": "11 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000068198860",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6351,7 +6351,7 @@
     "name": "11 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000102903647",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6383,7 +6383,7 @@
     "name": "11 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000081821453",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6399,7 +6399,7 @@
     "name": "11 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000089716230",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6431,7 +6431,7 @@
     "name": "11 FIG TERRACE GLENWOOD 2768",
     "locID": "LOC000027995110",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6463,7 +6463,7 @@
     "name": "11 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000101089579",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6479,7 +6479,7 @@
     "name": "11 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000040848331",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6495,7 +6495,7 @@
     "name": "11 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000086216982",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6511,7 +6511,7 @@
     "name": "11 GARNET GROVE GLENWOOD 2768",
     "locID": "LOC000054556227",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6575,7 +6575,7 @@
     "name": "11 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000061537349",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6591,7 +6591,7 @@
     "name": "11 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000024169040",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6607,7 +6607,7 @@
     "name": "11 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000054551283",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6655,7 +6655,7 @@
     "name": "11 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000024748530",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6671,7 +6671,7 @@
     "name": "11 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000032896046",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6687,7 +6687,7 @@
     "name": "11 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000025553108",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6719,7 +6719,7 @@
     "name": "11 HONEYEATER TERRACE GLENWOOD 2768",
     "locID": "LOC000036803241",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6735,7 +6735,7 @@
     "name": "11 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000077589823",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6751,7 +6751,7 @@
     "name": "11 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121986826",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6783,7 +6783,7 @@
     "name": "11 JOYCE STREET GLENWOOD 2768",
     "locID": "LOC000024580318",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6799,7 +6799,7 @@
     "name": "11 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000093998641",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6831,7 +6831,7 @@
     "name": "11 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000044453530",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6847,7 +6847,7 @@
     "name": "11 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000081221384",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6863,7 +6863,7 @@
     "name": "11 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000043520841",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6879,7 +6879,7 @@
     "name": "11 KOOKABURRA GROVE GLENWOOD 2768",
     "locID": "LOC000064846042",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6895,7 +6895,7 @@
     "name": "11 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000030402503",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6911,7 +6911,7 @@
     "name": "11 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000055755205",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6927,7 +6927,7 @@
     "name": "11 LEMON GROVE GLENWOOD 2768",
     "locID": "LOC000009866180",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6959,7 +6959,7 @@
     "name": "11 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000074465966",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -6975,7 +6975,7 @@
     "name": "11 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000104084092",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7007,7 +7007,7 @@
     "name": "11 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000153932669",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7023,7 +7023,7 @@
     "name": "11 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000062798800",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7039,7 +7039,7 @@
     "name": "11 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000059545860",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7055,7 +7055,7 @@
     "name": "11 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000075992743",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7071,7 +7071,7 @@
     "name": "11 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000009237455",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7087,7 +7087,7 @@
     "name": "11 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000101057025",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7135,7 +7135,7 @@
     "name": "11 MUSCAT GROVE GLENWOOD 2768",
     "locID": "LOC000056016572",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7151,7 +7151,7 @@
     "name": "11 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000083944544",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7167,7 +7167,7 @@
     "name": "11 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000075125500",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7183,7 +7183,7 @@
     "name": "11 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000004221069",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7199,7 +7199,7 @@
     "name": "11 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000067468546",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7215,7 +7215,7 @@
     "name": "11 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000092293095",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7231,7 +7231,7 @@
     "name": "11 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000052210706",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7247,7 +7247,7 @@
     "name": "11 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000091845069",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7263,7 +7263,7 @@
     "name": "11 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000065434795",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7279,7 +7279,7 @@
     "name": "11 PEACH GARDENS GLENWOOD 2768",
     "locID": "LOC000015759836",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7295,7 +7295,7 @@
     "name": "11 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000004035163",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7327,7 +7327,7 @@
     "name": "11 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000046702650",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7359,7 +7359,7 @@
     "name": "11 PINNACLE WAY GLENWOOD 2768",
     "locID": "LOC000034653438",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7375,7 +7375,7 @@
     "name": "11 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000078918719",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7391,7 +7391,7 @@
     "name": "11 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000077437962",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7407,7 +7407,7 @@
     "name": "11 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000113311361",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7439,7 +7439,7 @@
     "name": "11 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000043727565",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7487,7 +7487,7 @@
     "name": "11 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000032167942",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7503,7 +7503,7 @@
     "name": "11 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000034155465",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7519,7 +7519,7 @@
     "name": "11 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000088548432",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7535,7 +7535,7 @@
     "name": "11 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000032997269",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7599,7 +7599,7 @@
     "name": "11 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000070766413",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7615,7 +7615,7 @@
     "name": "11 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000080092750",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7647,7 +7647,7 @@
     "name": "11 STRAWBERRY WAY GLENWOOD 2768",
     "locID": "LOC000044097778",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7663,7 +7663,7 @@
     "name": "11 SULTANA GROVE GLENWOOD 2768",
     "locID": "LOC000084178776",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7679,7 +7679,7 @@
     "name": "11 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000082799078",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7711,7 +7711,7 @@
     "name": "11 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000090399044",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7743,7 +7743,7 @@
     "name": "11 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000081897999",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7759,7 +7759,7 @@
     "name": "11 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000114982653",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7791,7 +7791,7 @@
     "name": "11 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000055680289",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7823,7 +7823,7 @@
     "name": "11 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000086674930",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7839,7 +7839,7 @@
     "name": "11 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000028030059",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7855,7 +7855,7 @@
     "name": "11 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000018393203",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7871,7 +7871,7 @@
     "name": "11 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000079067564",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7887,7 +7887,7 @@
     "name": "11 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000064312862",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7903,7 +7903,7 @@
     "name": "11 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000009837565",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7935,7 +7935,7 @@
     "name": "110 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000030883212",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7951,7 +7951,7 @@
     "name": "111A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000110206740",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7967,7 +7967,7 @@
     "name": "111B MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000109894341",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -7999,7 +7999,7 @@
     "name": "112 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000046391204",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8015,7 +8015,7 @@
     "name": "113 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000026363497",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8031,7 +8031,7 @@
     "name": "113 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000079966364",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8047,7 +8047,7 @@
     "name": "114 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000040461508",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8079,7 +8079,7 @@
     "name": "114 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000062765914",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8095,7 +8095,7 @@
     "name": "115 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000094782789",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8111,7 +8111,7 @@
     "name": "115 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000092089113",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8127,7 +8127,7 @@
     "name": "116 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000021385672",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8159,7 +8159,7 @@
     "name": "116 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000072368536",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8175,7 +8175,7 @@
     "name": "117 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000105510503",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8207,7 +8207,7 @@
     "name": "118 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000098800428",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8239,7 +8239,7 @@
     "name": "118 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000023072060",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8255,7 +8255,7 @@
     "name": "119 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000014053916",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8271,7 +8271,7 @@
     "name": "119 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000089141063",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8319,7 +8319,7 @@
     "name": "119A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000089153296",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8351,7 +8351,7 @@
     "name": "12 ABDALE CRESCENT GLENWOOD 2768",
     "locID": "LOC000040218110",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8367,7 +8367,7 @@
     "name": "12 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000035758447",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8383,7 +8383,7 @@
     "name": "12 AGINCOURT PLACE GLENWOOD 2768",
     "locID": "LOC000057000576",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8399,7 +8399,7 @@
     "name": "12 ALI PLACE GLENWOOD 2768",
     "locID": "LOC000095995382",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8415,7 +8415,7 @@
     "name": "12 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000078477832",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8431,7 +8431,7 @@
     "name": "12 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000007416002",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8463,7 +8463,7 @@
     "name": "12 ANGEL COURT GLENWOOD 2768",
     "locID": "LOC000084415776",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8479,7 +8479,7 @@
     "name": "12 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000007405111",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8527,7 +8527,7 @@
     "name": "12 ARROWSMITH STREET GLENWOOD 2768",
     "locID": "LOC000074538033",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8543,7 +8543,7 @@
     "name": "12 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000104018508",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8591,7 +8591,7 @@
     "name": "12 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000014781374",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8607,7 +8607,7 @@
     "name": "12 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000043574693",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8623,7 +8623,7 @@
     "name": "12 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000055737216",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8639,7 +8639,7 @@
     "name": "12 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000045415547",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8671,7 +8671,7 @@
     "name": "12 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000073770897",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8687,7 +8687,7 @@
     "name": "12 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916201",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8703,7 +8703,7 @@
     "name": "12 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000086545978",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8719,7 +8719,7 @@
     "name": "12 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000045239688",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8735,7 +8735,7 @@
     "name": "12 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000103437909",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8751,7 +8751,7 @@
     "name": "12 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000004630356",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8767,7 +8767,7 @@
     "name": "12 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000107325191",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8783,7 +8783,7 @@
     "name": "12 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000038687831",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8831,7 +8831,7 @@
     "name": "12 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000082423895",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8847,7 +8847,7 @@
     "name": "12 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000002359060",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8895,7 +8895,7 @@
     "name": "12 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000092548723",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8911,7 +8911,7 @@
     "name": "12 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000064223263",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8927,7 +8927,7 @@
     "name": "12 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000087412509",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8959,7 +8959,7 @@
     "name": "12 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000109714003",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8975,7 +8975,7 @@
     "name": "12 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000102555172",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -8991,7 +8991,7 @@
     "name": "12 DARREN COURT GLENWOOD 2768",
     "locID": "LOC000070569948",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9007,7 +9007,7 @@
     "name": "12 DEAKIN AVENUE GLENWOOD 2768",
     "locID": "LOC000095330306",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9023,7 +9023,7 @@
     "name": "12 DENMAN COURT GLENWOOD 2768",
     "locID": "LOC000064546316",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9039,7 +9039,7 @@
     "name": "12 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000009086226",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9055,7 +9055,7 @@
     "name": "12 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000069394325",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9087,7 +9087,7 @@
     "name": "12 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000097637512",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9103,7 +9103,7 @@
     "name": "12 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000045378526",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9135,7 +9135,7 @@
     "name": "12 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000028688823",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9167,7 +9167,7 @@
     "name": "12 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000110092175",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9183,7 +9183,7 @@
     "name": "12 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000088986238",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9231,7 +9231,7 @@
     "name": "12 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000008818084",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9247,7 +9247,7 @@
     "name": "12 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000057291363",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9263,7 +9263,7 @@
     "name": "12 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000046811535",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9311,7 +9311,7 @@
     "name": "12 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000064391087",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9327,7 +9327,7 @@
     "name": "12 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000057250613",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9375,7 +9375,7 @@
     "name": "12 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000058447545",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9391,7 +9391,7 @@
     "name": "12 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000074278910",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9407,7 +9407,7 @@
     "name": "12 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000042911383",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9439,7 +9439,7 @@
     "name": "12 HOYA WAY GLENWOOD 2768",
     "locID": "LOC000121986857",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9455,7 +9455,7 @@
     "name": "12 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000093002420",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9471,7 +9471,7 @@
     "name": "12 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000006434481",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9487,7 +9487,7 @@
     "name": "12 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121986861",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9519,7 +9519,7 @@
     "name": "12 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000046592847",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9551,7 +9551,7 @@
     "name": "12 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000016797979",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9567,7 +9567,7 @@
     "name": "12 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000036777141",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9583,7 +9583,7 @@
     "name": "12 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000062049972",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9599,7 +9599,7 @@
     "name": "12 KOOKABURRA GROVE GLENWOOD 2768",
     "locID": "LOC000034798734",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9615,7 +9615,7 @@
     "name": "12 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000004087070",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9631,7 +9631,7 @@
     "name": "12 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000088742682",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9679,7 +9679,7 @@
     "name": "12 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000102722047",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9695,7 +9695,7 @@
     "name": "12 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000030487449",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9711,7 +9711,7 @@
     "name": "12 MAGPIE COURT GLENWOOD 2768",
     "locID": "LOC000121986874",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9743,7 +9743,7 @@
     "name": "12 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000035123090",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9759,7 +9759,7 @@
     "name": "12 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000011425346",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9775,7 +9775,7 @@
     "name": "12 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000084025086",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9791,7 +9791,7 @@
     "name": "12 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000039947003",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9823,7 +9823,7 @@
     "name": "12 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000101487721",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9839,7 +9839,7 @@
     "name": "12 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000090585429",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9855,7 +9855,7 @@
     "name": "12 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000003236461",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9871,7 +9871,7 @@
     "name": "12 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000016311332",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9887,7 +9887,7 @@
     "name": "12 NEWNES CLOSE GLENWOOD 2768",
     "locID": "LOC000046542399",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9903,7 +9903,7 @@
     "name": "12 NIXON STREET GLENWOOD 2768",
     "locID": "LOC000042097731",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9919,7 +9919,7 @@
     "name": "12 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000052183687",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9935,7 +9935,7 @@
     "name": "12 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000019661604",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9951,7 +9951,7 @@
     "name": "12 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000092921411",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9967,7 +9967,7 @@
     "name": "12 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000032168250",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9983,7 +9983,7 @@
     "name": "12 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000047697271",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -9999,7 +9999,7 @@
     "name": "12 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000076912619",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10015,7 +10015,7 @@
     "name": "12 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000063540725",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10031,7 +10031,7 @@
     "name": "12 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000105404441",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10063,7 +10063,7 @@
     "name": "12 PERIDOT PLACE GLENWOOD 2768",
     "locID": "LOC000082604946",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10079,7 +10079,7 @@
     "name": "12 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000098358005",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10111,7 +10111,7 @@
     "name": "12 PINNACLE WAY GLENWOOD 2768",
     "locID": "LOC000055655236",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10127,7 +10127,7 @@
     "name": "12 PLUM GARDENS GLENWOOD 2768",
     "locID": "LOC000049739005",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10143,7 +10143,7 @@
     "name": "12 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000023253405",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10159,7 +10159,7 @@
     "name": "12 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000026251028",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10175,7 +10175,7 @@
     "name": "12 RAYWOOD COURT GLENWOOD 2768",
     "locID": "LOC000042166220",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10191,7 +10191,7 @@
     "name": "12 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000014748817",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10223,7 +10223,7 @@
     "name": "12 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000114964451",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10255,7 +10255,7 @@
     "name": "12 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000024162699",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10319,7 +10319,7 @@
     "name": "12 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000013297236",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10335,7 +10335,7 @@
     "name": "12 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000042437772",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10383,7 +10383,7 @@
     "name": "12 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000022954686",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10399,7 +10399,7 @@
     "name": "12 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000169699737",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10415,7 +10415,7 @@
     "name": "12 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000043485297",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10431,7 +10431,7 @@
     "name": "12 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000055376014",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10463,7 +10463,7 @@
     "name": "12 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000074870538",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10479,7 +10479,7 @@
     "name": "12 SWANSEA COURT GLENWOOD 2768",
     "locID": "LOC000115113246",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10511,7 +10511,7 @@
     "name": "12 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000094555136",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10527,7 +10527,7 @@
     "name": "12 TAWNY CLOSE GLENWOOD 2768",
     "locID": "LOC000040192562",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10543,7 +10543,7 @@
     "name": "12 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000100001231",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10559,7 +10559,7 @@
     "name": "12 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000072074452",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10575,7 +10575,7 @@
     "name": "12 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000052429122",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10607,7 +10607,7 @@
     "name": "12 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000042581866",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10623,7 +10623,7 @@
     "name": "12 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000083008552",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10639,7 +10639,7 @@
     "name": "12 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000007271822",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10655,7 +10655,7 @@
     "name": "12 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000002342715",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10671,7 +10671,7 @@
     "name": "12 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000044121567",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10703,7 +10703,7 @@
     "name": "120 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000066449383",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10735,7 +10735,7 @@
     "name": "121 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000092272452",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10751,7 +10751,7 @@
     "name": "121 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000108295522",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10767,7 +10767,7 @@
     "name": "122 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000018000762",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10783,7 +10783,7 @@
     "name": "123 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000065411361",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10799,7 +10799,7 @@
     "name": "123 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000053260125",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10815,7 +10815,7 @@
     "name": "124 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000063906439",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10831,7 +10831,7 @@
     "name": "125 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000048094850",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10847,7 +10847,7 @@
     "name": "125 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000023867741",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10863,7 +10863,7 @@
     "name": "126 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000023673152",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10879,7 +10879,7 @@
     "name": "127 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000061047929",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10895,7 +10895,7 @@
     "name": "127 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000024642331",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10911,7 +10911,7 @@
     "name": "128 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000090408708",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10927,7 +10927,7 @@
     "name": "129 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000068374328",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10943,7 +10943,7 @@
     "name": "129 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000099279619",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -10991,7 +10991,7 @@
     "name": "12A PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000076834525",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11039,7 +11039,7 @@
     "name": "12B SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000060390900",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11055,7 +11055,7 @@
     "name": "13 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000038155070",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11071,7 +11071,7 @@
     "name": "13 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000042816651",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11087,7 +11087,7 @@
     "name": "13 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000048193817",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11103,7 +11103,7 @@
     "name": "13 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000058684922",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11135,7 +11135,7 @@
     "name": "13 ANITA STREET GLENWOOD 2768",
     "locID": "LOC000004146061",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11183,7 +11183,7 @@
     "name": "13 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000067129392",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11199,7 +11199,7 @@
     "name": "13 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000040702946",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11215,7 +11215,7 @@
     "name": "13 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000093577049",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11231,7 +11231,7 @@
     "name": "13 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000045152948",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11263,7 +11263,7 @@
     "name": "13 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000086419263",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11279,7 +11279,7 @@
     "name": "13 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916217",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11295,7 +11295,7 @@
     "name": "13 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000013991908",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11311,7 +11311,7 @@
     "name": "13 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000005972968",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11327,7 +11327,7 @@
     "name": "13 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000080054039",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11343,7 +11343,7 @@
     "name": "13 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000075038177",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11359,7 +11359,7 @@
     "name": "13 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000092111427",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11391,7 +11391,7 @@
     "name": "13 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000103440059",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11407,7 +11407,7 @@
     "name": "13 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000025535043",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11455,7 +11455,7 @@
     "name": "13 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000034079676",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11503,7 +11503,7 @@
     "name": "13 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000099333510",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11519,7 +11519,7 @@
     "name": "13 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000095667247",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11535,7 +11535,7 @@
     "name": "13 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000065106600",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11567,7 +11567,7 @@
     "name": "13 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000075850222",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11583,7 +11583,7 @@
     "name": "13 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000094672538",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11599,7 +11599,7 @@
     "name": "13 EAGLE WAY GLENWOOD 2768",
     "locID": "LOC000058344619",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11631,7 +11631,7 @@
     "name": "13 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000018869729",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11647,7 +11647,7 @@
     "name": "13 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000076695978",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11679,7 +11679,7 @@
     "name": "13 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000029714148",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11711,7 +11711,7 @@
     "name": "13 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000058561831",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11727,7 +11727,7 @@
     "name": "13 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000087537137",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11759,7 +11759,7 @@
     "name": "13 FIG TERRACE GLENWOOD 2768",
     "locID": "LOC000069097030",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11791,7 +11791,7 @@
     "name": "13 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000078489594",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11807,7 +11807,7 @@
     "name": "13 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000081394417",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11823,7 +11823,7 @@
     "name": "13 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000024634559",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11839,7 +11839,7 @@
     "name": "13 GARNET GROVE GLENWOOD 2768",
     "locID": "LOC000071278399",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11903,7 +11903,7 @@
     "name": "13 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000021355450",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11919,7 +11919,7 @@
     "name": "13 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000100843315",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11935,7 +11935,7 @@
     "name": "13 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000089213373",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11983,7 +11983,7 @@
     "name": "13 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000012895617",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -11999,7 +11999,7 @@
     "name": "13 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000049169069",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12015,7 +12015,7 @@
     "name": "13 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000026801600",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12047,7 +12047,7 @@
     "name": "13 HONEYEATER TERRACE GLENWOOD 2768",
     "locID": "LOC000053559531",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12063,7 +12063,7 @@
     "name": "13 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000033127978",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12079,7 +12079,7 @@
     "name": "13 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121986890",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12111,7 +12111,7 @@
     "name": "13 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000080117423",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12143,7 +12143,7 @@
     "name": "13 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000056029978",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12159,7 +12159,7 @@
     "name": "13 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000048293561",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12175,7 +12175,7 @@
     "name": "13 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000004743128",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12191,7 +12191,7 @@
     "name": "13 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000028040640",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12207,7 +12207,7 @@
     "name": "13 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000013296284",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12223,7 +12223,7 @@
     "name": "13 LEMON GROVE GLENWOOD 2768",
     "locID": "LOC000029982385",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12255,7 +12255,7 @@
     "name": "13 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000065130833",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12271,7 +12271,7 @@
     "name": "13 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000014543457",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12303,7 +12303,7 @@
     "name": "13 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000055052134",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12319,7 +12319,7 @@
     "name": "13 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000062602219",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12335,7 +12335,7 @@
     "name": "13 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000025950139",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12351,7 +12351,7 @@
     "name": "13 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000002256649",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12367,7 +12367,7 @@
     "name": "13 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000070558967",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12399,7 +12399,7 @@
     "name": "13 MUSCAT GROVE GLENWOOD 2768",
     "locID": "LOC000066514894",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12415,7 +12415,7 @@
     "name": "13 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000075000994",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12431,7 +12431,7 @@
     "name": "13 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000100149098",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12447,7 +12447,7 @@
     "name": "13 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000068884877",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12463,7 +12463,7 @@
     "name": "13 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000098659272",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12479,7 +12479,7 @@
     "name": "13 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000007261038",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12495,7 +12495,7 @@
     "name": "13 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000003765216",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12511,7 +12511,7 @@
     "name": "13 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000089181789",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12527,7 +12527,7 @@
     "name": "13 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000054906259",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12543,7 +12543,7 @@
     "name": "13 PEACH GARDENS GLENWOOD 2768",
     "locID": "LOC000012339334",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12559,7 +12559,7 @@
     "name": "13 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000053374154",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12591,7 +12591,7 @@
     "name": "13 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000063897558",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12623,7 +12623,7 @@
     "name": "13 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000098875576",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12639,7 +12639,7 @@
     "name": "13 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000090471108",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12655,7 +12655,7 @@
     "name": "13 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000115059619",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12687,7 +12687,7 @@
     "name": "13 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000031479883",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12735,7 +12735,7 @@
     "name": "13 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000032883169",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12751,7 +12751,7 @@
     "name": "13 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000099991435",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12767,7 +12767,7 @@
     "name": "13 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000037569700",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12783,7 +12783,7 @@
     "name": "13 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000058842341",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12831,7 +12831,7 @@
     "name": "13 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000032193517",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12847,7 +12847,7 @@
     "name": "13 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000028014759",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12863,7 +12863,7 @@
     "name": "13 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000035853958",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12895,7 +12895,7 @@
     "name": "13 STRAWBERRY WAY GLENWOOD 2768",
     "locID": "LOC000107309770",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12911,7 +12911,7 @@
     "name": "13 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000004206142",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12943,7 +12943,7 @@
     "name": "13 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000080998234",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12959,7 +12959,7 @@
     "name": "13 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000041282839",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12975,7 +12975,7 @@
     "name": "13 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000113262915",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -12991,7 +12991,7 @@
     "name": "13 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000003808934",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13023,7 +13023,7 @@
     "name": "13 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000099971069",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13039,7 +13039,7 @@
     "name": "13 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000005530915",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13055,7 +13055,7 @@
     "name": "13 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000063427660",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13071,7 +13071,7 @@
     "name": "13 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000069575807",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13087,7 +13087,7 @@
     "name": "130 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000072160314",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13103,7 +13103,7 @@
     "name": "131 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000059126698",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13119,7 +13119,7 @@
     "name": "132 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000009736648",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13135,7 +13135,7 @@
     "name": "132A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000021355450",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13151,7 +13151,7 @@
     "name": "132B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000021388253",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13167,7 +13167,7 @@
     "name": "133 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000098434497",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13183,7 +13183,7 @@
     "name": "134 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000065061816",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13199,7 +13199,7 @@
     "name": "135 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000011709863",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13215,7 +13215,7 @@
     "name": "135 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000108603436",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13231,7 +13231,7 @@
     "name": "136 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000082020870",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13247,7 +13247,7 @@
     "name": "137 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000013923166",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13263,7 +13263,7 @@
     "name": "137 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000055919604",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13279,7 +13279,7 @@
     "name": "137B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000049389814",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13295,7 +13295,7 @@
     "name": "138 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000034656184",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13311,7 +13311,7 @@
     "name": "139 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000099409442",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13327,7 +13327,7 @@
     "name": "139A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000086247985",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13343,7 +13343,7 @@
     "name": "139B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000086353599",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13359,7 +13359,7 @@
     "name": "14 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000087446607",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13375,7 +13375,7 @@
     "name": "14 ALI PLACE GLENWOOD 2768",
     "locID": "LOC000048534386",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13391,7 +13391,7 @@
     "name": "14 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000043759672",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13407,7 +13407,7 @@
     "name": "14 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000033825551",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13423,7 +13423,7 @@
     "name": "14 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000001348835",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13455,7 +13455,7 @@
     "name": "14 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000011810698",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13503,7 +13503,7 @@
     "name": "14 ARROWSMITH STREET GLENWOOD 2768",
     "locID": "LOC000021226369",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13519,7 +13519,7 @@
     "name": "14 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000055503209",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13567,7 +13567,7 @@
     "name": "14 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000051996140",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13583,7 +13583,7 @@
     "name": "14 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000048432387",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13599,7 +13599,7 @@
     "name": "14 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000013239292",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13615,7 +13615,7 @@
     "name": "14 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000110162869",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13647,7 +13647,7 @@
     "name": "14 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000088047715",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13663,7 +13663,7 @@
     "name": "14 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916229",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13679,7 +13679,7 @@
     "name": "14 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000052217691",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13695,7 +13695,7 @@
     "name": "14 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000045659326",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13711,7 +13711,7 @@
     "name": "14 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000024701703",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13727,7 +13727,7 @@
     "name": "14 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000062046349",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13743,7 +13743,7 @@
     "name": "14 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000014946542",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13791,7 +13791,7 @@
     "name": "14 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000006499311",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13807,7 +13807,7 @@
     "name": "14 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000039543937",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13855,7 +13855,7 @@
     "name": "14 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000022142026",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13887,7 +13887,7 @@
     "name": "14 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000071090696",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13919,7 +13919,7 @@
     "name": "14 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000104902347",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13935,7 +13935,7 @@
     "name": "14 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000032543827",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13951,7 +13951,7 @@
     "name": "14 DEAKIN AVENUE GLENWOOD 2768",
     "locID": "LOC000080864048",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13967,7 +13967,7 @@
     "name": "14 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000107167173",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -13983,7 +13983,7 @@
     "name": "14 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000078825085",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14015,7 +14015,7 @@
     "name": "14 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000074316066",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14031,7 +14031,7 @@
     "name": "14 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000105062239",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14095,7 +14095,7 @@
     "name": "14 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000001405833",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14111,7 +14111,7 @@
     "name": "14 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000021338548",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14159,7 +14159,7 @@
     "name": "14 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000077341645",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14175,7 +14175,7 @@
     "name": "14 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000044184689",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14191,7 +14191,7 @@
     "name": "14 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000054148086",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14239,7 +14239,7 @@
     "name": "14 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000081854356",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14255,7 +14255,7 @@
     "name": "14 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000024588796",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14303,7 +14303,7 @@
     "name": "14 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000063354745",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14319,7 +14319,7 @@
     "name": "14 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000014788395",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14335,7 +14335,7 @@
     "name": "14 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000063952757",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14367,7 +14367,7 @@
     "name": "14 HOYA WAY GLENWOOD 2768",
     "locID": "LOC000121986959",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14383,7 +14383,7 @@
     "name": "14 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000099943628",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14399,7 +14399,7 @@
     "name": "14 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000005593292",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14415,7 +14415,7 @@
     "name": "14 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121986963",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14447,7 +14447,7 @@
     "name": "14 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000065244426",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14463,7 +14463,7 @@
     "name": "14 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000053373378",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14479,7 +14479,7 @@
     "name": "14 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000081775412",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14495,7 +14495,7 @@
     "name": "14 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000040598970",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14511,7 +14511,7 @@
     "name": "14 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000018098066",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14527,7 +14527,7 @@
     "name": "14 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000057266681",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14575,7 +14575,7 @@
     "name": "14 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000015596487",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14591,7 +14591,7 @@
     "name": "14 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000071457348",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14623,7 +14623,7 @@
     "name": "14 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000035456789",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14639,7 +14639,7 @@
     "name": "14 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000102346951",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14655,7 +14655,7 @@
     "name": "14 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000063985100",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14671,7 +14671,7 @@
     "name": "14 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000087506383",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14687,7 +14687,7 @@
     "name": "14 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000015540863",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14703,7 +14703,7 @@
     "name": "14 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000074006717",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14719,7 +14719,7 @@
     "name": "14 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000028030517",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14735,7 +14735,7 @@
     "name": "14 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000092042888",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14751,7 +14751,7 @@
     "name": "14 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000080798285",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14767,7 +14767,7 @@
     "name": "14 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000097533463",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14783,7 +14783,7 @@
     "name": "14 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000099862954",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14799,7 +14799,7 @@
     "name": "14 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000084200267",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14815,7 +14815,7 @@
     "name": "14 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000008307875",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14831,7 +14831,7 @@
     "name": "14 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000087248717",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14847,7 +14847,7 @@
     "name": "14 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000043628667",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14879,7 +14879,7 @@
     "name": "14 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000084075592",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14911,7 +14911,7 @@
     "name": "14 PLUM GARDENS GLENWOOD 2768",
     "locID": "LOC000043210519",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14927,7 +14927,7 @@
     "name": "14 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000031296571",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14943,7 +14943,7 @@
     "name": "14 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000012377421",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14959,7 +14959,7 @@
     "name": "14 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000004596287",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -14975,7 +14975,7 @@
     "name": "14 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000114308659",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15007,7 +15007,7 @@
     "name": "14 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000060929507",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15055,7 +15055,7 @@
     "name": "14 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000019824761",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15071,7 +15071,7 @@
     "name": "14 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000030463447",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15119,7 +15119,7 @@
     "name": "14 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000086733258",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15135,7 +15135,7 @@
     "name": "14 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000115545538",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15151,7 +15151,7 @@
     "name": "14 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000077609315",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15167,7 +15167,7 @@
     "name": "14 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000061048211",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15199,7 +15199,7 @@
     "name": "14 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000047025481",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15231,7 +15231,7 @@
     "name": "14 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000083235239",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15247,7 +15247,7 @@
     "name": "14 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000107746802",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15263,7 +15263,7 @@
     "name": "14 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000006428330",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15279,7 +15279,7 @@
     "name": "14 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000036125784",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15295,7 +15295,7 @@
     "name": "14 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000090773959",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15327,7 +15327,7 @@
     "name": "14 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000020894482",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15343,7 +15343,7 @@
     "name": "14 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000065169623",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15359,7 +15359,7 @@
     "name": "14 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000081106170",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15375,7 +15375,7 @@
     "name": "14 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000069337780",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15391,7 +15391,7 @@
     "name": "14 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000076839580",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15407,7 +15407,7 @@
     "name": "140 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000059581109",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15455,7 +15455,7 @@
     "name": "141 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000039907794",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15471,7 +15471,7 @@
     "name": "141 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000005467377",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15487,7 +15487,7 @@
     "name": "142 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000058401104",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15503,7 +15503,7 @@
     "name": "143 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000026198085",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15519,7 +15519,7 @@
     "name": "143 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000108603436",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15551,7 +15551,7 @@
     "name": "144 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000046302407",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15567,7 +15567,7 @@
     "name": "145 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000071078344",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15583,7 +15583,7 @@
     "name": "145 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000015440202",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15599,7 +15599,7 @@
     "name": "146 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000069713912",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15615,7 +15615,7 @@
     "name": "147 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000099727126",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15631,7 +15631,7 @@
     "name": "147 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121986971",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15647,7 +15647,7 @@
     "name": "148 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000078684000",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15679,7 +15679,7 @@
     "name": "148A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000078730179",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15695,7 +15695,7 @@
     "name": "148B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000078684000",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15711,7 +15711,7 @@
     "name": "149 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000101823097",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15727,7 +15727,7 @@
     "name": "149 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000153932522",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15743,7 +15743,7 @@
     "name": "14A ARROWSMITH STREET GLENWOOD 2768",
     "locID": "LOC000021226369",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15759,7 +15759,7 @@
     "name": "14B ARROWSMITH STREET GLENWOOD 2768",
     "locID": "LOC000021501817",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15775,7 +15775,7 @@
     "name": "15 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000066663207",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15791,7 +15791,7 @@
     "name": "15 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000107214050",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15807,7 +15807,7 @@
     "name": "15 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000033291186",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15823,7 +15823,7 @@
     "name": "15 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000078908628",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15855,7 +15855,7 @@
     "name": "15 ANITA STREET GLENWOOD 2768",
     "locID": "LOC000007262147",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15919,7 +15919,7 @@
     "name": "15 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000024790400",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15935,7 +15935,7 @@
     "name": "15 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000018397262",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15951,7 +15951,7 @@
     "name": "15 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000087190554",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -15999,7 +15999,7 @@
     "name": "15 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000045886131",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16015,7 +16015,7 @@
     "name": "15 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916238",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16031,7 +16031,7 @@
     "name": "15 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000072856489",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16047,7 +16047,7 @@
     "name": "15 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000104413053",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16063,7 +16063,7 @@
     "name": "15 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000015602784",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16079,7 +16079,7 @@
     "name": "15 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000016835947",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16095,7 +16095,7 @@
     "name": "15 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000101830144",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16127,7 +16127,7 @@
     "name": "15 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000072623564",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16143,7 +16143,7 @@
     "name": "15 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000055622980",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16191,7 +16191,7 @@
     "name": "15 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000013041092",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16239,7 +16239,7 @@
     "name": "15 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000023066369",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16255,7 +16255,7 @@
     "name": "15 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000076502093",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16271,7 +16271,7 @@
     "name": "15 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000039746781",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16303,7 +16303,7 @@
     "name": "15 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000059342974",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16319,7 +16319,7 @@
     "name": "15 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000101345769",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16351,7 +16351,7 @@
     "name": "15 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000031281602",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16367,7 +16367,7 @@
     "name": "15 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000089571087",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16399,7 +16399,7 @@
     "name": "15 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000078676822",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16431,7 +16431,7 @@
     "name": "15 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000085496860",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16463,7 +16463,7 @@
     "name": "15 FIG TERRACE GLENWOOD 2768",
     "locID": "LOC000033912397",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16495,7 +16495,7 @@
     "name": "15 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000065247872",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16511,7 +16511,7 @@
     "name": "15 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000092126101",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16527,7 +16527,7 @@
     "name": "15 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000018802440",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16543,7 +16543,7 @@
     "name": "15 GARNET GROVE GLENWOOD 2768",
     "locID": "LOC000014748829",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16607,7 +16607,7 @@
     "name": "15 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000052473676",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16623,7 +16623,7 @@
     "name": "15 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000103563168",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16639,7 +16639,7 @@
     "name": "15 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000076000190",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16687,7 +16687,7 @@
     "name": "15 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000085125549",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16703,7 +16703,7 @@
     "name": "15 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000081922503",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16719,7 +16719,7 @@
     "name": "15 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000054497905",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16751,7 +16751,7 @@
     "name": "15 HONEYEATER TERRACE GLENWOOD 2768",
     "locID": "LOC000019795286",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16767,7 +16767,7 @@
     "name": "15 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000087038232",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16783,7 +16783,7 @@
     "name": "15 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000049586677",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16799,7 +16799,7 @@
     "name": "15 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121990132",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16831,7 +16831,7 @@
     "name": "15 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000086208942",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16863,7 +16863,7 @@
     "name": "15 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000057454905",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16879,7 +16879,7 @@
     "name": "15 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000023114390",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16895,7 +16895,7 @@
     "name": "15 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000035445715",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16911,7 +16911,7 @@
     "name": "15 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000086248898",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16927,7 +16927,7 @@
     "name": "15 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000042191323",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16959,7 +16959,7 @@
     "name": "15 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000032325901",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -16975,7 +16975,7 @@
     "name": "15 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000062469431",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17007,7 +17007,7 @@
     "name": "15 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000019748698",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17023,7 +17023,7 @@
     "name": "15 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000090105610",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17039,7 +17039,7 @@
     "name": "15 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000071461096",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17055,7 +17055,7 @@
     "name": "15 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000038105373",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17071,7 +17071,7 @@
     "name": "15 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000030051236",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17103,7 +17103,7 @@
     "name": "15 MUSCAT GROVE GLENWOOD 2768",
     "locID": "LOC000062944459",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17119,7 +17119,7 @@
     "name": "15 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000016236524",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17135,7 +17135,7 @@
     "name": "15 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000029592554",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17151,7 +17151,7 @@
     "name": "15 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000003214061",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17167,7 +17167,7 @@
     "name": "15 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000074916377",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17183,7 +17183,7 @@
     "name": "15 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000017910897",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17199,7 +17199,7 @@
     "name": "15 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000047766278",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17231,7 +17231,7 @@
     "name": "15 PEACH GARDENS GLENWOOD 2768",
     "locID": "LOC000089554948",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17247,7 +17247,7 @@
     "name": "15 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000076860426",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17279,7 +17279,7 @@
     "name": "15 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000068671446",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17311,7 +17311,7 @@
     "name": "15 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000023253405",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17327,7 +17327,7 @@
     "name": "15 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000097004361",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17359,7 +17359,7 @@
     "name": "15 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000008968435",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17407,7 +17407,7 @@
     "name": "15 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000003113231",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17423,7 +17423,7 @@
     "name": "15 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000108331732",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17439,7 +17439,7 @@
     "name": "15 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000107445364",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17487,7 +17487,7 @@
     "name": "15 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000095894311",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17503,7 +17503,7 @@
     "name": "15 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000021990715",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17519,7 +17519,7 @@
     "name": "15 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000032349802",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17551,7 +17551,7 @@
     "name": "15 STRAWBERRY WAY GLENWOOD 2768",
     "locID": "LOC000046775270",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17567,7 +17567,7 @@
     "name": "15 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000107507175",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17599,7 +17599,7 @@
     "name": "15 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000045983298",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17615,7 +17615,7 @@
     "name": "15 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000023146335",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17631,7 +17631,7 @@
     "name": "15 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000113089771",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17647,7 +17647,7 @@
     "name": "15 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000022239063",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17663,7 +17663,7 @@
     "name": "15 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000007157876",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17695,7 +17695,7 @@
     "name": "15 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000072451536",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17711,7 +17711,7 @@
     "name": "15 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000041946666",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17727,7 +17727,7 @@
     "name": "15 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000051894253",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17743,7 +17743,7 @@
     "name": "150 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000094679554",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17775,7 +17775,7 @@
     "name": "151 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000018447925",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17791,7 +17791,7 @@
     "name": "151 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990145",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17807,7 +17807,7 @@
     "name": "152 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000052473676",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17839,7 +17839,7 @@
     "name": "153 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990150",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17855,7 +17855,7 @@
     "name": "154 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000077330258",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17887,7 +17887,7 @@
     "name": "155 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000101790121",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17903,7 +17903,7 @@
     "name": "155 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990166",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17919,7 +17919,7 @@
     "name": "156 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000005971633",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17935,7 +17935,7 @@
     "name": "157 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000029620306",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17951,7 +17951,7 @@
     "name": "157 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990178",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17967,7 +17967,7 @@
     "name": "158 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000095540617",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17983,7 +17983,7 @@
     "name": "159 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000074171982",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -17999,7 +17999,7 @@
     "name": "15A BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000104413053",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18015,7 +18015,7 @@
     "name": "15A FIG TERRACE GLENWOOD 2768",
     "locID": "LOC000033912397",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18079,7 +18079,7 @@
     "name": "15B BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000104292368",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18095,7 +18095,7 @@
     "name": "15B FIG TERRACE GLENWOOD 2768",
     "locID": "LOC000033865773",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18127,7 +18127,7 @@
     "name": "16 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000069537249",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18143,7 +18143,7 @@
     "name": "16 ALI PLACE GLENWOOD 2768",
     "locID": "LOC000098540897",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18175,7 +18175,7 @@
     "name": "16 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000047163441",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18191,7 +18191,7 @@
     "name": "16 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000003810899",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18223,7 +18223,7 @@
     "name": "16 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000034654202",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18271,7 +18271,7 @@
     "name": "16 ARROWSMITH STREET GLENWOOD 2768",
     "locID": "LOC000098969224",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18287,7 +18287,7 @@
     "name": "16 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000021505504",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18319,7 +18319,7 @@
     "name": "16 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000034854409",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18335,7 +18335,7 @@
     "name": "16 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000077274165",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18351,7 +18351,7 @@
     "name": "16 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000101611847",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18367,7 +18367,7 @@
     "name": "16 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000019754131",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18399,7 +18399,7 @@
     "name": "16 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000056007172",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18415,7 +18415,7 @@
     "name": "16 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916240",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18431,7 +18431,7 @@
     "name": "16 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000003796687",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18447,7 +18447,7 @@
     "name": "16 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000046899140",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18463,7 +18463,7 @@
     "name": "16 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000090527370",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18479,7 +18479,7 @@
     "name": "16 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000094572651",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18495,7 +18495,7 @@
     "name": "16 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000024527342",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18543,7 +18543,7 @@
     "name": "16 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000054374781",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18559,7 +18559,7 @@
     "name": "16 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000043337733",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18591,7 +18591,7 @@
     "name": "16 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000024850992",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18623,7 +18623,7 @@
     "name": "16 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000092968398",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18655,7 +18655,7 @@
     "name": "16 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000071478753",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18671,7 +18671,7 @@
     "name": "16 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000023856202",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18687,7 +18687,7 @@
     "name": "16 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000020670122",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18703,7 +18703,7 @@
     "name": "16 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000078607803",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18735,7 +18735,7 @@
     "name": "16 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000053346016",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18767,7 +18767,7 @@
     "name": "16 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000031318474",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18799,7 +18799,7 @@
     "name": "16 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000075869802",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18847,7 +18847,7 @@
     "name": "16 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000050461657",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18863,7 +18863,7 @@
     "name": "16 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000070716040",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18879,7 +18879,7 @@
     "name": "16 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000088563964",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18927,7 +18927,7 @@
     "name": "16 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000103581150",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18943,7 +18943,7 @@
     "name": "16 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000025934361",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -18991,7 +18991,7 @@
     "name": "16 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000025837463",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19007,7 +19007,7 @@
     "name": "16 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000022209385",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19023,7 +19023,7 @@
     "name": "16 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000063436814",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19039,7 +19039,7 @@
     "name": "16 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000015969667",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19055,7 +19055,7 @@
     "name": "16 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000046812786",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19071,7 +19071,7 @@
     "name": "16 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121990184",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19103,7 +19103,7 @@
     "name": "16 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000057458365",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19119,7 +19119,7 @@
     "name": "16 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000043371598",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19135,7 +19135,7 @@
     "name": "16 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000098274768",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19151,7 +19151,7 @@
     "name": "16 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000061107443",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19167,7 +19167,7 @@
     "name": "16 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000075131001",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19215,7 +19215,7 @@
     "name": "16 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000015058319",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19231,7 +19231,7 @@
     "name": "16 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000042852728",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19263,7 +19263,7 @@
     "name": "16 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000109810674",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19279,7 +19279,7 @@
     "name": "16 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000039228771",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19295,7 +19295,7 @@
     "name": "16 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000059614125",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19311,7 +19311,7 @@
     "name": "16 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000064959581",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19327,7 +19327,7 @@
     "name": "16 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000001578753",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19343,7 +19343,7 @@
     "name": "16 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000006279112",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19359,7 +19359,7 @@
     "name": "16 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000012370111",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19375,7 +19375,7 @@
     "name": "16 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000097839819",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19391,7 +19391,7 @@
     "name": "16 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000097963601",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19407,7 +19407,7 @@
     "name": "16 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000080784977",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19423,7 +19423,7 @@
     "name": "16 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000014637675",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19439,7 +19439,7 @@
     "name": "16 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000017835699",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19455,7 +19455,7 @@
     "name": "16 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000101719465",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19471,7 +19471,7 @@
     "name": "16 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000098487864",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19519,7 +19519,7 @@
     "name": "16 PLUM GARDENS GLENWOOD 2768",
     "locID": "LOC000025059644",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19535,7 +19535,7 @@
     "name": "16 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000036111934",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19551,7 +19551,7 @@
     "name": "16 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000038069895",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19567,7 +19567,7 @@
     "name": "16 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000087586126",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19583,7 +19583,7 @@
     "name": "16 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000114438031",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19615,7 +19615,7 @@
     "name": "16 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000067780780",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19663,7 +19663,7 @@
     "name": "16 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000035716355",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19711,7 +19711,7 @@
     "name": "16 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000096365391",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19727,7 +19727,7 @@
     "name": "16 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000055353076",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19743,7 +19743,7 @@
     "name": "16 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000022878178",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19759,7 +19759,7 @@
     "name": "16 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000008761783",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19791,7 +19791,7 @@
     "name": "16 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000005957502",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19823,7 +19823,7 @@
     "name": "16 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000070837574",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19839,7 +19839,7 @@
     "name": "16 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000038034878",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19855,7 +19855,7 @@
     "name": "16 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000054848635",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19871,7 +19871,7 @@
     "name": "16 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000062959763",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19887,7 +19887,7 @@
     "name": "16 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000087709839",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19919,7 +19919,7 @@
     "name": "16 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000028943618",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19935,7 +19935,7 @@
     "name": "16 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000099155270",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19951,7 +19951,7 @@
     "name": "16 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000101838773",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -19967,7 +19967,7 @@
     "name": "16 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000020994406",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20031,7 +20031,7 @@
     "name": "161 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990204",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20047,7 +20047,7 @@
     "name": "162 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000063327814",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20063,7 +20063,7 @@
     "name": "162 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000092089113",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20079,7 +20079,7 @@
     "name": "162A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000063327814",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20095,7 +20095,7 @@
     "name": "162B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000063237630",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20127,7 +20127,7 @@
     "name": "163 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990215",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20143,7 +20143,7 @@
     "name": "164 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000078835941",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20175,7 +20175,7 @@
     "name": "165 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990227",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20191,7 +20191,7 @@
     "name": "166 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000035065236",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20207,7 +20207,7 @@
     "name": "166 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000153954507",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20223,7 +20223,7 @@
     "name": "167 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990236",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20239,7 +20239,7 @@
     "name": "167A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000014651681",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20255,7 +20255,7 @@
     "name": "167A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990243",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20271,7 +20271,7 @@
     "name": "167B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000014527864",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20287,7 +20287,7 @@
     "name": "168 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000035400479",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20303,7 +20303,7 @@
     "name": "168 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000153954530",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20319,7 +20319,7 @@
     "name": "169 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990258",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20335,7 +20335,7 @@
     "name": "169A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000052806510",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20351,7 +20351,7 @@
     "name": "169A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000115545540",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20367,7 +20367,7 @@
     "name": "169B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000052643510",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20383,7 +20383,7 @@
     "name": "16A DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000023863874",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20415,7 +20415,7 @@
     "name": "16A STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000008761783",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20431,7 +20431,7 @@
     "name": "16B DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000023856202",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20447,7 +20447,7 @@
     "name": "16B STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000009010412",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20463,7 +20463,7 @@
     "name": "17 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000062091665",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20479,7 +20479,7 @@
     "name": "17 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000082598223",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20495,7 +20495,7 @@
     "name": "17 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000039855726",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20511,7 +20511,7 @@
     "name": "17 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000024907000",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20559,7 +20559,7 @@
     "name": "17 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000032236810",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20575,7 +20575,7 @@
     "name": "17 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000037367301",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20591,7 +20591,7 @@
     "name": "17 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000015003756",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20639,7 +20639,7 @@
     "name": "17 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000005557584",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20655,7 +20655,7 @@
     "name": "17 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916255",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20671,7 +20671,7 @@
     "name": "17 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000025044198",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20687,7 +20687,7 @@
     "name": "17 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000071001602",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20703,7 +20703,7 @@
     "name": "17 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000088403532",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20719,7 +20719,7 @@
     "name": "17 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000054077798",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20735,7 +20735,7 @@
     "name": "17 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000099007565",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20783,7 +20783,7 @@
     "name": "17 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000015096888",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20815,7 +20815,7 @@
     "name": "17 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000025493317",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20831,7 +20831,7 @@
     "name": "17 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000067389527",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20847,7 +20847,7 @@
     "name": "17 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000036974811",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20895,7 +20895,7 @@
     "name": "17 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000052807781",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20927,7 +20927,7 @@
     "name": "17 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000057162138",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -20943,7 +20943,7 @@
     "name": "17 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000006567496",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21039,7 +21039,7 @@
     "name": "17 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000013198874",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21055,7 +21055,7 @@
     "name": "17 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000071127436",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21071,7 +21071,7 @@
     "name": "17 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000049412866",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21087,7 +21087,7 @@
     "name": "17 GARNET GROVE GLENWOOD 2768",
     "locID": "LOC000102406262",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21135,7 +21135,7 @@
     "name": "17 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000035201304",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21151,7 +21151,7 @@
     "name": "17 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000056390637",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21199,7 +21199,7 @@
     "name": "17 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000024748530",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21215,7 +21215,7 @@
     "name": "17 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000063929727",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21231,7 +21231,7 @@
     "name": "17 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000086759622",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21263,7 +21263,7 @@
     "name": "17 HONEYEATER TERRACE GLENWOOD 2768",
     "locID": "LOC000016404193",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21279,7 +21279,7 @@
     "name": "17 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000028856987",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21295,7 +21295,7 @@
     "name": "17 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000065023054",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21343,7 +21343,7 @@
     "name": "17 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000032140086",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21375,7 +21375,7 @@
     "name": "17 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000065340715",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21391,7 +21391,7 @@
     "name": "17 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000057172713",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21407,7 +21407,7 @@
     "name": "17 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000103165683",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21439,7 +21439,7 @@
     "name": "17 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000085026534",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21471,7 +21471,7 @@
     "name": "17 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000100331232",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21487,7 +21487,7 @@
     "name": "17 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000032368317",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21503,7 +21503,7 @@
     "name": "17 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000078427352",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21519,7 +21519,7 @@
     "name": "17 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000107328945",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21535,7 +21535,7 @@
     "name": "17 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000079030904",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21567,7 +21567,7 @@
     "name": "17 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000021580735",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21583,7 +21583,7 @@
     "name": "17 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000004669296",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21599,7 +21599,7 @@
     "name": "17 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000035963876",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21615,7 +21615,7 @@
     "name": "17 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000018946917",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21631,7 +21631,7 @@
     "name": "17 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000042582955",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21647,7 +21647,7 @@
     "name": "17 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000043549044",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21663,7 +21663,7 @@
     "name": "17 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000074586504",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21679,7 +21679,7 @@
     "name": "17 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000014995503",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21695,7 +21695,7 @@
     "name": "17 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000089210862",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21743,7 +21743,7 @@
     "name": "17 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000088415327",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21791,7 +21791,7 @@
     "name": "17 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000089933895",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21807,7 +21807,7 @@
     "name": "17 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000088057175",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21823,7 +21823,7 @@
     "name": "17 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000005541725",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21871,7 +21871,7 @@
     "name": "17 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000107337691",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21887,7 +21887,7 @@
     "name": "17 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000009705558",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21903,7 +21903,7 @@
     "name": "17 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000027293424",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21919,7 +21919,7 @@
     "name": "17 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000071000672",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21951,7 +21951,7 @@
     "name": "17 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000022194628",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21983,7 +21983,7 @@
     "name": "17 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000032983856",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -21999,7 +21999,7 @@
     "name": "17 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000097127884",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22015,7 +22015,7 @@
     "name": "17 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000026331491",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22031,7 +22031,7 @@
     "name": "17 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000114612730",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22047,7 +22047,7 @@
     "name": "17 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000069249688",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22063,7 +22063,7 @@
     "name": "17 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000096154729",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22095,7 +22095,7 @@
     "name": "17 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000090473123",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22111,7 +22111,7 @@
     "name": "17 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000106457650",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22127,7 +22127,7 @@
     "name": "17 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000074308501",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22143,7 +22143,7 @@
     "name": "170 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000029575207",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22159,7 +22159,7 @@
     "name": "171 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000103091986",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22175,7 +22175,7 @@
     "name": "171 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990289",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22191,7 +22191,7 @@
     "name": "171A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990291",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22207,7 +22207,7 @@
     "name": "172 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000058870890",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22223,7 +22223,7 @@
     "name": "173 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000004747542",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22239,7 +22239,7 @@
     "name": "173 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990301",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22255,7 +22255,7 @@
     "name": "173A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000115545555",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22271,7 +22271,7 @@
     "name": "174 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000069423228",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22287,7 +22287,7 @@
     "name": "174 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000002369229",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22303,7 +22303,7 @@
     "name": "175 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000088087947",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22319,7 +22319,7 @@
     "name": "175 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000160936168",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22335,7 +22335,7 @@
     "name": "175A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000160936168",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22351,7 +22351,7 @@
     "name": "175B MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000160945971",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22367,7 +22367,7 @@
     "name": "176 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000007186116",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22383,7 +22383,7 @@
     "name": "177 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000160946005",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22399,7 +22399,7 @@
     "name": "177A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000086159637",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22415,7 +22415,7 @@
     "name": "177A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000160946014",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22431,7 +22431,7 @@
     "name": "177B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000086176705",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22447,7 +22447,7 @@
     "name": "177B MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000160946022",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22463,7 +22463,7 @@
     "name": "178 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000069439488",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22479,7 +22479,7 @@
     "name": "179 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000004630838",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22511,7 +22511,7 @@
     "name": "17A BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000024090355",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22527,7 +22527,7 @@
     "name": "17B BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000023901530",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22543,7 +22543,7 @@
     "name": "18 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000053544710",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22559,7 +22559,7 @@
     "name": "18 ALI PLACE GLENWOOD 2768",
     "locID": "LOC000101906193",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22575,7 +22575,7 @@
     "name": "18 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000049584154",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22591,7 +22591,7 @@
     "name": "18 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000048275536",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22639,7 +22639,7 @@
     "name": "18 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000053926590",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22671,7 +22671,7 @@
     "name": "18 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000023708770",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22687,7 +22687,7 @@
     "name": "18 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000093545993",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22703,7 +22703,7 @@
     "name": "18 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000007285009",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22719,7 +22719,7 @@
     "name": "18 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000027197908",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22751,7 +22751,7 @@
     "name": "18 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000078793258",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22767,7 +22767,7 @@
     "name": "18 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916264",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22783,7 +22783,7 @@
     "name": "18 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000038050682",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22799,7 +22799,7 @@
     "name": "18 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000099719545",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22815,7 +22815,7 @@
     "name": "18 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000069007745",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22831,7 +22831,7 @@
     "name": "18 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000046124806",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22879,7 +22879,7 @@
     "name": "18 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000103118415",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22895,7 +22895,7 @@
     "name": "18 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000011536889",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22927,7 +22927,7 @@
     "name": "18 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000055887654",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22959,7 +22959,7 @@
     "name": "18 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000053222971",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -22991,7 +22991,7 @@
     "name": "18 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000030497400",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23007,7 +23007,7 @@
     "name": "18 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000062492774",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23023,7 +23023,7 @@
     "name": "18 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000068271036",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23039,7 +23039,7 @@
     "name": "18 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000099409305",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23071,7 +23071,7 @@
     "name": "18 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000097862837",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23103,7 +23103,7 @@
     "name": "18 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000080990227",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23135,7 +23135,7 @@
     "name": "18 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000010509002",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23183,7 +23183,7 @@
     "name": "18 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000093322984",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23199,7 +23199,7 @@
     "name": "18 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000072853475",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23231,7 +23231,7 @@
     "name": "18 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000053021391",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23295,7 +23295,7 @@
     "name": "18 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000108282811",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23311,7 +23311,7 @@
     "name": "18 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000046072981",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23327,7 +23327,7 @@
     "name": "18 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000081275067",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23343,7 +23343,7 @@
     "name": "18 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000087364866",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23359,7 +23359,7 @@
     "name": "18 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000105434066",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23375,7 +23375,7 @@
     "name": "18 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121990317",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23407,7 +23407,7 @@
     "name": "18 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000044238057",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23423,7 +23423,7 @@
     "name": "18 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000013328552",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23439,7 +23439,7 @@
     "name": "18 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000041642357",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23455,7 +23455,7 @@
     "name": "18 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000075834726",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23503,7 +23503,7 @@
     "name": "18 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000020659071",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23519,7 +23519,7 @@
     "name": "18 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000035692537",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23551,7 +23551,7 @@
     "name": "18 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000105163519",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23567,7 +23567,7 @@
     "name": "18 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000037876725",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23583,7 +23583,7 @@
     "name": "18 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000083736315",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23599,7 +23599,7 @@
     "name": "18 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000071239461",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23615,7 +23615,7 @@
     "name": "18 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000101487721",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23631,7 +23631,7 @@
     "name": "18 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000004086293",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23647,7 +23647,7 @@
     "name": "18 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000002368194",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23663,7 +23663,7 @@
     "name": "18 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000024231922",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23679,7 +23679,7 @@
     "name": "18 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000017206792",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23695,7 +23695,7 @@
     "name": "18 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000059109205",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23711,7 +23711,7 @@
     "name": "18 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000009673868",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23727,7 +23727,7 @@
     "name": "18 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000066384312",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23743,7 +23743,7 @@
     "name": "18 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000040258453",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23775,7 +23775,7 @@
     "name": "18 PLUM GARDENS GLENWOOD 2768",
     "locID": "LOC000025534984",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23791,7 +23791,7 @@
     "name": "18 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000070912761",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23807,7 +23807,7 @@
     "name": "18 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000039859346",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23839,7 +23839,7 @@
     "name": "18 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000051878649",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23887,7 +23887,7 @@
     "name": "18 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000044489457",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23935,7 +23935,7 @@
     "name": "18 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000101929011",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23951,7 +23951,7 @@
     "name": "18 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000077944943",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23967,7 +23967,7 @@
     "name": "18 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000074795900",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23983,7 +23983,7 @@
     "name": "18 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000048825855",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -23999,7 +23999,7 @@
     "name": "18 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000088158306",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24031,7 +24031,7 @@
     "name": "18 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000080878860",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24047,7 +24047,7 @@
     "name": "18 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000027985470",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24063,7 +24063,7 @@
     "name": "18 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000082799195",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24079,7 +24079,7 @@
     "name": "18 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000014054035",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24095,7 +24095,7 @@
     "name": "18 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000010077860",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24111,7 +24111,7 @@
     "name": "18 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000034139833",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24127,7 +24127,7 @@
     "name": "18 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000050739012",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24143,7 +24143,7 @@
     "name": "18 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000078832013",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24159,7 +24159,7 @@
     "name": "18 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000080103248",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24175,7 +24175,7 @@
     "name": "180 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000063717012",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24191,7 +24191,7 @@
     "name": "181 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000044155447",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24223,7 +24223,7 @@
     "name": "182 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000052380654",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24239,7 +24239,7 @@
     "name": "183 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000059070376",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24287,7 +24287,7 @@
     "name": "184 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000024693704",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24303,7 +24303,7 @@
     "name": "185 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000107277023",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24367,7 +24367,7 @@
     "name": "186 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000002466557",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24383,7 +24383,7 @@
     "name": "187 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000013849127",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24415,7 +24415,7 @@
     "name": "188 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000014151370",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24431,7 +24431,7 @@
     "name": "189 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000077195565",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24495,7 +24495,7 @@
     "name": "18A WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000010077860",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24511,7 +24511,7 @@
     "name": "19 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000098528821",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24527,7 +24527,7 @@
     "name": "19 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000020593546",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24543,7 +24543,7 @@
     "name": "19 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000098255816",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24591,7 +24591,7 @@
     "name": "19 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000092273193",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24607,7 +24607,7 @@
     "name": "19 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000080047229",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24623,7 +24623,7 @@
     "name": "19 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000098557983",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24671,7 +24671,7 @@
     "name": "19 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916272",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24687,7 +24687,7 @@
     "name": "19 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000019665583",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24703,7 +24703,7 @@
     "name": "19 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000034117415",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24719,7 +24719,7 @@
     "name": "19 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000110144051",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24735,7 +24735,7 @@
     "name": "19 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000015871219",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24751,7 +24751,7 @@
     "name": "19 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000034893897",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24799,7 +24799,7 @@
     "name": "19 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000025425480",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24831,7 +24831,7 @@
     "name": "19 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000023099731",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24847,7 +24847,7 @@
     "name": "19 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000052311404",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24895,7 +24895,7 @@
     "name": "19 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000015703118",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24927,7 +24927,7 @@
     "name": "19 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000051819680",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -24943,7 +24943,7 @@
     "name": "19 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000082743800",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25023,7 +25023,7 @@
     "name": "19 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000039769765",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25039,7 +25039,7 @@
     "name": "19 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000032776939",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25055,7 +25055,7 @@
     "name": "19 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000051384103",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25071,7 +25071,7 @@
     "name": "19 GARNET GROVE GLENWOOD 2768",
     "locID": "LOC000098151652",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25119,7 +25119,7 @@
     "name": "19 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000026764233",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25135,7 +25135,7 @@
     "name": "19 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000015514604",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25183,7 +25183,7 @@
     "name": "19 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000005107342",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25199,7 +25199,7 @@
     "name": "19 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000104935338",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25215,7 +25215,7 @@
     "name": "19 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000078821755",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25247,7 +25247,7 @@
     "name": "19 HONEYEATER TERRACE GLENWOOD 2768",
     "locID": "LOC000089434535",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25263,7 +25263,7 @@
     "name": "19 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000087554150",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25279,7 +25279,7 @@
     "name": "19 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000025036942",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25327,7 +25327,7 @@
     "name": "19 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000072521394",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25359,7 +25359,7 @@
     "name": "19 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000080417812",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25375,7 +25375,7 @@
     "name": "19 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000033140773",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25391,7 +25391,7 @@
     "name": "19 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000036787905",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25423,7 +25423,7 @@
     "name": "19 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000087295991",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25439,7 +25439,7 @@
     "name": "19 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000040442509",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25455,7 +25455,7 @@
     "name": "19 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000007300712",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25471,7 +25471,7 @@
     "name": "19 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000023066557",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25487,7 +25487,7 @@
     "name": "19 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000013067337",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25503,7 +25503,7 @@
     "name": "19 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000089231507",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25519,7 +25519,7 @@
     "name": "19 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000053824305",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25535,7 +25535,7 @@
     "name": "19 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000038231275",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25551,7 +25551,7 @@
     "name": "19 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000034809828",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25567,7 +25567,7 @@
     "name": "19 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000045104388",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25583,7 +25583,7 @@
     "name": "19 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000051534957",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25599,7 +25599,7 @@
     "name": "19 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000100213502",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25631,7 +25631,7 @@
     "name": "19 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000093431979",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25679,7 +25679,7 @@
     "name": "19 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000012117270",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25695,7 +25695,7 @@
     "name": "19 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000067308499",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25743,7 +25743,7 @@
     "name": "19 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000016390094",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25759,7 +25759,7 @@
     "name": "19 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000043510845",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25775,7 +25775,7 @@
     "name": "19 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000022153225",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25791,7 +25791,7 @@
     "name": "19 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000096250725",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25823,7 +25823,7 @@
     "name": "19 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000040614307",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25855,7 +25855,7 @@
     "name": "19 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000005675214",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25887,7 +25887,7 @@
     "name": "19 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000114707716",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25903,7 +25903,7 @@
     "name": "19 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000103998323",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25919,7 +25919,7 @@
     "name": "19 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000013780427",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25951,7 +25951,7 @@
     "name": "19 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000049570419",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25983,7 +25983,7 @@
     "name": "19 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000044346367",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -25999,7 +25999,7 @@
     "name": "190 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000004180662",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26015,7 +26015,7 @@
     "name": "190A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000121990340",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26031,7 +26031,7 @@
     "name": "191 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000029144924",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26063,7 +26063,7 @@
     "name": "192 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000108173347",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26079,7 +26079,7 @@
     "name": "193 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000075704362",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26127,7 +26127,7 @@
     "name": "195 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000046177955",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26191,7 +26191,7 @@
     "name": "197 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000089729984",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26255,7 +26255,7 @@
     "name": "19A SILVERTOP CLOSE GLENWOOD 2768",
     "locID": "LOC000190240722",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26271,7 +26271,7 @@
     "name": "19A SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000022409530",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26287,7 +26287,7 @@
     "name": "1A BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000153919980",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26303,7 +26303,7 @@
     "name": "1B BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000153917252",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26319,7 +26319,7 @@
     "name": "1B FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000042483982",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26335,7 +26335,7 @@
     "name": "2 ALI PLACE GLENWOOD 2768",
     "locID": "LOC000076863897",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26351,7 +26351,7 @@
     "name": "2 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000059542788",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26367,7 +26367,7 @@
     "name": "2 ALPINE WAY GLENWOOD 2768",
     "locID": "LOC000013085159",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26383,7 +26383,7 @@
     "name": "2 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000101270713",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26399,7 +26399,7 @@
     "name": "2 AMUET PLACE GLENWOOD 2768",
     "locID": "LOC000087345755",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26431,7 +26431,7 @@
     "name": "2 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000071046209",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26463,7 +26463,7 @@
     "name": "2 ARNIKA COURT GLENWOOD 2768",
     "locID": "LOC000153913540",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26495,7 +26495,7 @@
     "name": "2 ARROWSMITH STREET GLENWOOD 2768",
     "locID": "LOC000098359812",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26511,7 +26511,7 @@
     "name": "2 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000081908896",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26527,7 +26527,7 @@
     "name": "2 AVRIL COURT GLENWOOD 2768",
     "locID": "LOC000049056412",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26591,7 +26591,7 @@
     "name": "2 BAIL WAY GLENWOOD 2768",
     "locID": "LOC000075077229",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26607,7 +26607,7 @@
     "name": "2 BARBER PLACE GLENWOOD 2768",
     "locID": "LOC000050321001",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26623,7 +26623,7 @@
     "name": "2 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000061359463",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26639,7 +26639,7 @@
     "name": "2 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000048475830",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26655,7 +26655,7 @@
     "name": "2 BETH WAY GLENWOOD 2768",
     "locID": "LOC000007271155",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26719,7 +26719,7 @@
     "name": "2 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000019878859",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26735,7 +26735,7 @@
     "name": "2 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000092041400",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26751,7 +26751,7 @@
     "name": "2 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000103423273",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26767,7 +26767,7 @@
     "name": "2 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000083856722",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26783,7 +26783,7 @@
     "name": "2 CAROONA WAY GLENWOOD 2768",
     "locID": "LOC000099857691",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26799,7 +26799,7 @@
     "name": "2 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000064012976",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26815,7 +26815,7 @@
     "name": "2 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000004661116",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26847,7 +26847,7 @@
     "name": "2 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000032969449",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26863,7 +26863,7 @@
     "name": "2 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000040134059",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26895,7 +26895,7 @@
     "name": "2 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000009019216",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26943,7 +26943,7 @@
     "name": "2 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000078982354",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26959,7 +26959,7 @@
     "name": "2 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000102555172",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26975,7 +26975,7 @@
     "name": "2 DARE STREET GLENWOOD 2768",
     "locID": "LOC000090486384",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -26991,7 +26991,7 @@
     "name": "2 DARREN COURT GLENWOOD 2768",
     "locID": "LOC000012285721",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27023,7 +27023,7 @@
     "name": "2 DEAKIN AVENUE GLENWOOD 2768",
     "locID": "LOC000065087653",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27039,7 +27039,7 @@
     "name": "2 DENMAN COURT GLENWOOD 2768",
     "locID": "LOC000091661837",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27055,7 +27055,7 @@
     "name": "2 DIENELT CLOSE GLENWOOD 2768",
     "locID": "LOC000034096048",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27071,7 +27071,7 @@
     "name": "2 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000153922782",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27103,7 +27103,7 @@
     "name": "2 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000019850359",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27119,7 +27119,7 @@
     "name": "2 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000043296919",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27167,7 +27167,7 @@
     "name": "2 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000030601314",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27183,7 +27183,7 @@
     "name": "2 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000053327404",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27231,7 +27231,7 @@
     "name": "2 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000062207134",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27247,7 +27247,7 @@
     "name": "2 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000093945277",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27295,7 +27295,7 @@
     "name": "2 GLENLEA COURT GLENWOOD 2768",
     "locID": "LOC000005442323",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27327,7 +27327,7 @@
     "name": "2 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000083988828",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27375,7 +27375,7 @@
     "name": "2 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000033929436",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27391,7 +27391,7 @@
     "name": "2 HAMBRO AVENUE GLENWOOD 2768",
     "locID": "LOC000096047443",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27407,7 +27407,7 @@
     "name": "2 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000100039294",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27423,7 +27423,7 @@
     "name": "2 HERITAGE PLACE GLENWOOD 2768",
     "locID": "LOC000053171304",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27439,7 +27439,7 @@
     "name": "2 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000101608922",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27455,7 +27455,7 @@
     "name": "2 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000001580972",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27487,7 +27487,7 @@
     "name": "2 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121986861",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27519,7 +27519,7 @@
     "name": "2 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000092612935",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27551,7 +27551,7 @@
     "name": "2 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000047989493",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27583,7 +27583,7 @@
     "name": "2 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000184730774",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27599,7 +27599,7 @@
     "name": "2 KOOKABURRA GROVE GLENWOOD 2768",
     "locID": "LOC000009598677",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27631,7 +27631,7 @@
     "name": "2 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000099856130",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27647,7 +27647,7 @@
     "name": "2 LEMON GROVE GLENWOOD 2768",
     "locID": "LOC000031374927",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27677,7 +27677,7 @@
    },
    "properties": {
     "name": "2 LORD WAY GLENWOOD 2768",
-    "locID": "LOC000074244613",
+    "locID": "LOC000001480510",
     "tech": "FTTN",
     "upgrade": "FTTP_NA"
    }
@@ -27695,7 +27695,7 @@
     "name": "2 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000036901917",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27727,7 +27727,7 @@
     "name": "2 MALEY GROVE GLENWOOD 2768",
     "locID": "LOC000013161217",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27743,7 +27743,7 @@
     "name": "2 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000019284279",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27759,7 +27759,7 @@
     "name": "2 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000009708415",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27775,7 +27775,7 @@
     "name": "2 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000096298489",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27791,7 +27791,7 @@
     "name": "2 MARS WAY GLENWOOD 2768",
     "locID": "LOC000106437963",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27823,7 +27823,7 @@
     "name": "2 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000062433003",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27839,7 +27839,7 @@
     "name": "2 MCMAHON GROVE GLENWOOD 2768",
     "locID": "LOC000042397974",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27855,7 +27855,7 @@
     "name": "2 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000018312402",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27871,7 +27871,7 @@
     "name": "2 MINKI WAY GLENWOOD 2768",
     "locID": "LOC000004641304",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27887,7 +27887,7 @@
     "name": "2 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000088045795",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27903,7 +27903,7 @@
     "name": "2 NESH PLACE GLENWOOD 2768",
     "locID": "LOC000121993240",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27919,7 +27919,7 @@
     "name": "2 NEWNES CLOSE GLENWOOD 2768",
     "locID": "LOC000028904324",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27935,7 +27935,7 @@
     "name": "2 NIXON STREET GLENWOOD 2768",
     "locID": "LOC000075478327",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27951,7 +27951,7 @@
     "name": "2 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000077998886",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27967,7 +27967,7 @@
     "name": "2 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000071597444",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27983,7 +27983,7 @@
     "name": "2 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000064914155",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -27999,7 +27999,7 @@
     "name": "2 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000020564109",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28015,7 +28015,7 @@
     "name": "2 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000176129265",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28031,7 +28031,7 @@
     "name": "2 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000069253733",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28047,7 +28047,7 @@
     "name": "2 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000021391230",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28079,7 +28079,7 @@
     "name": "2 PERIDOT PLACE GLENWOOD 2768",
     "locID": "LOC000097464849",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28127,7 +28127,7 @@
     "name": "2 PINNACLE WAY GLENWOOD 2768",
     "locID": "LOC000023799317",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28143,7 +28143,7 @@
     "name": "2 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000098875576",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28159,7 +28159,7 @@
     "name": "2 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000060321062",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28175,7 +28175,7 @@
     "name": "2 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000078771594",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28191,7 +28191,7 @@
     "name": "2 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000080529874",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28223,7 +28223,7 @@
     "name": "2 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000115052759",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28255,7 +28255,7 @@
     "name": "2 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000086642482",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28271,7 +28271,7 @@
     "name": "2 RYDER STREET GLENWOOD 2768",
     "locID": "LOC000058236587",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28335,7 +28335,7 @@
     "name": "2 SENTINEL STREET GLENWOOD 2768",
     "locID": "LOC000084971973",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28351,7 +28351,7 @@
     "name": "2 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000038927780",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28383,7 +28383,7 @@
     "name": "2 SILVERTON STREET GLENWOOD 2768",
     "locID": "LOC000043256550",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28415,7 +28415,7 @@
     "name": "2 SOLAR PLACE GLENWOOD 2768",
     "locID": "LOC000026788404",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28431,7 +28431,7 @@
     "name": "2 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000057719770",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28447,7 +28447,7 @@
     "name": "2 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000085233846",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28463,7 +28463,7 @@
     "name": "2 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000094612860",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28479,7 +28479,7 @@
     "name": "2 SWANSEA COURT GLENWOOD 2768",
     "locID": "LOC000115080495",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28511,7 +28511,7 @@
     "name": "2 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000041768050",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28527,7 +28527,7 @@
     "name": "2 TAWNY CLOSE GLENWOOD 2768",
     "locID": "LOC000057201104",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28543,7 +28543,7 @@
     "name": "2 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000065402962",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28559,7 +28559,7 @@
     "name": "2 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000041920148",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28591,7 +28591,7 @@
     "name": "2 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000025451363",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28623,7 +28623,7 @@
     "name": "2 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000057167550",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28639,7 +28639,7 @@
     "name": "2 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000076923899",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28655,7 +28655,7 @@
     "name": "2 WILLOWLEAF CLOSE GLENWOOD 2768",
     "locID": "LOC000064874446",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28671,7 +28671,7 @@
     "name": "2 YANCO GLEN GLENWOOD 2768",
     "locID": "LOC000052339379",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28703,7 +28703,7 @@
     "name": "2 ZENITH COURT GLENWOOD 2768",
     "locID": "LOC000069522615",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28719,7 +28719,7 @@
     "name": "20 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000041295589",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28735,7 +28735,7 @@
     "name": "20 ALI PLACE GLENWOOD 2768",
     "locID": "LOC000084161319",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28751,7 +28751,7 @@
     "name": "20 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000068944901",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28767,7 +28767,7 @@
     "name": "20 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000099642218",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28815,7 +28815,7 @@
     "name": "20 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000153913670",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28863,7 +28863,7 @@
     "name": "20 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000085637926",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28879,7 +28879,7 @@
     "name": "20 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000107256678",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28911,7 +28911,7 @@
     "name": "20 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000017938178",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28927,7 +28927,7 @@
     "name": "20 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916286",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28943,7 +28943,7 @@
     "name": "20 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000046126222",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28959,7 +28959,7 @@
     "name": "20 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000088186577",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -28991,7 +28991,7 @@
     "name": "20 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000075407074",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29039,7 +29039,7 @@
     "name": "20 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000019771386",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29055,7 +29055,7 @@
     "name": "20 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000073496250",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29087,7 +29087,7 @@
     "name": "20 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000064379844",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29119,7 +29119,7 @@
     "name": "20 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000097667308",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29151,7 +29151,7 @@
     "name": "20 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000034070827",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29167,7 +29167,7 @@
     "name": "20 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000003856943",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29183,7 +29183,7 @@
     "name": "20 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000097988668",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29199,7 +29199,7 @@
     "name": "20 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000099748299",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29215,7 +29215,7 @@
     "name": "20 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000063685142",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29247,7 +29247,7 @@
     "name": "20 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000003743575",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29279,7 +29279,7 @@
     "name": "20 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000023966351",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29327,7 +29327,7 @@
     "name": "20 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000048008717",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29343,7 +29343,7 @@
     "name": "20 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000115545564",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29359,7 +29359,7 @@
     "name": "20 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000005089829",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29423,7 +29423,7 @@
     "name": "20 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000035121628",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29439,7 +29439,7 @@
     "name": "20 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000020575938",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29455,7 +29455,7 @@
     "name": "20 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000035613759",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29471,7 +29471,7 @@
     "name": "20 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121993264",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29503,7 +29503,7 @@
     "name": "20 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000066721068",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29519,7 +29519,7 @@
     "name": "20 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000002322673",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29535,7 +29535,7 @@
     "name": "20 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000067664783",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29551,7 +29551,7 @@
     "name": "20 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000040266556",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29599,7 +29599,7 @@
     "name": "20 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000057058357",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29615,7 +29615,7 @@
     "name": "20 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000029629932",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29647,7 +29647,7 @@
     "name": "20 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000046251668",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29663,7 +29663,7 @@
     "name": "20 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000057117214",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29679,7 +29679,7 @@
     "name": "20 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000009599313",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29711,7 +29711,7 @@
     "name": "20 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000047471792",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29727,7 +29727,7 @@
     "name": "20 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000028352656",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29743,7 +29743,7 @@
     "name": "20 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000096616012",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29759,7 +29759,7 @@
     "name": "20 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000070975784",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29775,7 +29775,7 @@
     "name": "20 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000010610214",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29791,7 +29791,7 @@
     "name": "20 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000075260849",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29823,7 +29823,7 @@
     "name": "20 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000102964750",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29839,7 +29839,7 @@
     "name": "20 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000055755897",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29871,7 +29871,7 @@
     "name": "20 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000084811017",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29903,7 +29903,7 @@
     "name": "20 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000064846090",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29951,7 +29951,7 @@
     "name": "20 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000096978712",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29967,7 +29967,7 @@
     "name": "20 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000055863509",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29983,7 +29983,7 @@
     "name": "20 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000039938669",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -29999,7 +29999,7 @@
     "name": "20 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000102686775",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30015,7 +30015,7 @@
     "name": "20 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000052949614",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30047,7 +30047,7 @@
     "name": "20 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000022836950",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30063,7 +30063,7 @@
     "name": "20 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000084282498",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30079,7 +30079,7 @@
     "name": "20 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000002388659",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30095,7 +30095,7 @@
     "name": "20 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000054647356",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30111,7 +30111,7 @@
     "name": "20 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000092354072",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30127,7 +30127,7 @@
     "name": "20 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000098561257",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30143,7 +30143,7 @@
     "name": "20 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000044175540",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30159,7 +30159,7 @@
     "name": "20 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000064005356",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30271,7 +30271,7 @@
     "name": "205 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000026378092",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30383,7 +30383,7 @@
     "name": "20A LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000121993272",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30399,7 +30399,7 @@
     "name": "21 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000059542788",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30415,7 +30415,7 @@
     "name": "21 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000085971086",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30431,7 +30431,7 @@
     "name": "21 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000101160408",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30479,7 +30479,7 @@
     "name": "21 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000099959895",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30495,7 +30495,7 @@
     "name": "21 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000005411973",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30509,9 +30509,9 @@
    },
    "properties": {
     "name": "21 BLUEBERRY GROVE GLENWOOD 2768",
-    "locID": "LOC000110162869",
+    "locID": "LOC000070837640",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30543,7 +30543,7 @@
     "name": "21 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916293",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30559,7 +30559,7 @@
     "name": "21 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000083116368",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30575,7 +30575,7 @@
     "name": "21 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000072632969",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30591,7 +30591,7 @@
     "name": "21 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000075476841",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30607,7 +30607,7 @@
     "name": "21 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000013094786",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30623,7 +30623,7 @@
     "name": "21 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000099878369",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30671,7 +30671,7 @@
     "name": "21 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000051850828",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30703,7 +30703,7 @@
     "name": "21 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000061588662",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30767,7 +30767,7 @@
     "name": "21 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000092267398",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30783,7 +30783,7 @@
     "name": "21 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000071533156",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30863,7 +30863,7 @@
     "name": "21 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000063799133",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30879,7 +30879,7 @@
     "name": "21 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000025585175",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30895,7 +30895,7 @@
     "name": "21 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000081211179",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30911,7 +30911,7 @@
     "name": "21 GARNET GROVE GLENWOOD 2768",
     "locID": "LOC000030932459",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30959,7 +30959,7 @@
     "name": "21 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000074712530",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30975,7 +30975,7 @@
     "name": "21 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000027985692",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -30991,7 +30991,7 @@
     "name": "21 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000064073560",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31023,7 +31023,7 @@
     "name": "21 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000105366930",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31039,7 +31039,7 @@
     "name": "21 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000078734088",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31055,7 +31055,7 @@
     "name": "21 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000055690734",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31071,7 +31071,7 @@
     "name": "21 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000083076387",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31087,7 +31087,7 @@
     "name": "21 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000084087902",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31135,7 +31135,7 @@
     "name": "21 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000078498417",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31167,7 +31167,7 @@
     "name": "21 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000012275780",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31183,7 +31183,7 @@
     "name": "21 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000064739252",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31199,7 +31199,7 @@
     "name": "21 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000038970060",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31231,7 +31231,7 @@
     "name": "21 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000018790412",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31247,7 +31247,7 @@
     "name": "21 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000080786463",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31263,7 +31263,7 @@
     "name": "21 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000026503452",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31279,7 +31279,7 @@
     "name": "21 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000086437904",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31295,7 +31295,7 @@
     "name": "21 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000022275515",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31311,7 +31311,7 @@
     "name": "21 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000043249366",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31327,7 +31327,7 @@
     "name": "21 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000042239597",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31343,7 +31343,7 @@
     "name": "21 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000089991664",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31359,7 +31359,7 @@
     "name": "21 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000060043224",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31375,7 +31375,7 @@
     "name": "21 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000086649628",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31391,7 +31391,7 @@
     "name": "21 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000025570094",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31423,7 +31423,7 @@
     "name": "21 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000068771913",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31471,7 +31471,7 @@
     "name": "21 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000057427635",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31487,7 +31487,7 @@
     "name": "21 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000011265924",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31519,7 +31519,7 @@
     "name": "21 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000086214932",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31535,7 +31535,7 @@
     "name": "21 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000078535211",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31551,7 +31551,7 @@
     "name": "21 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000086728318",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31583,7 +31583,7 @@
     "name": "21 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000015789911",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31615,7 +31615,7 @@
     "name": "21 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000084236909",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31631,7 +31631,7 @@
     "name": "21 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000063085276",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31647,7 +31647,7 @@
     "name": "21 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000114297710",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31663,7 +31663,7 @@
     "name": "21 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000049793548",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31679,7 +31679,7 @@
     "name": "21 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000067537803",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31711,7 +31711,7 @@
     "name": "21 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000045836983",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31759,7 +31759,7 @@
     "name": "211 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000063617055",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31807,7 +31807,7 @@
     "name": "213 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000052198732",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31855,7 +31855,7 @@
     "name": "215 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000055384740",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31887,7 +31887,7 @@
     "name": "216 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000078408198",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31919,7 +31919,7 @@
     "name": "217 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000078019211",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31951,7 +31951,7 @@
     "name": "218 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000090656733",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -31983,7 +31983,7 @@
     "name": "219 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000091848959",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32015,7 +32015,7 @@
     "name": "21A PEAK STREET GLENWOOD 2768",
     "locID": "LOC000025417987",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32047,7 +32047,7 @@
     "name": "22 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000054489802",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32063,7 +32063,7 @@
     "name": "22 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000052813838",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32079,7 +32079,7 @@
     "name": "22 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000082291960",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32127,7 +32127,7 @@
     "name": "22 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000153913689",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32159,7 +32159,7 @@
     "name": "22 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000071062887",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32175,7 +32175,7 @@
     "name": "22 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000065031775",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32191,7 +32191,7 @@
     "name": "22 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000091644825",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32207,7 +32207,7 @@
     "name": "22 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000103346005",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32223,7 +32223,7 @@
     "name": "22 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153917101",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32239,7 +32239,7 @@
     "name": "22 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000044543078",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32255,7 +32255,7 @@
     "name": "22 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000064562206",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32271,7 +32271,7 @@
     "name": "22 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000014117424",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32319,7 +32319,7 @@
     "name": "22 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000102392625",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32335,7 +32335,7 @@
     "name": "22 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000068340719",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32367,7 +32367,7 @@
     "name": "22 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000008317288",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32415,7 +32415,7 @@
     "name": "22 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000078008088",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32431,7 +32431,7 @@
     "name": "22 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000022328398",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32479,7 +32479,7 @@
     "name": "22 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000030632908",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32511,7 +32511,7 @@
     "name": "22 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000034004221",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32527,7 +32527,7 @@
     "name": "22 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000006574491",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32591,7 +32591,7 @@
     "name": "22 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000077470159",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32607,7 +32607,7 @@
     "name": "22 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000102505095",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32623,7 +32623,7 @@
     "name": "22 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000090572142",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32639,7 +32639,7 @@
     "name": "22 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000017157277",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32655,7 +32655,7 @@
     "name": "22 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121993293",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32687,7 +32687,7 @@
     "name": "22 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000106473629",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32703,7 +32703,7 @@
     "name": "22 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000037429406",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32719,7 +32719,7 @@
     "name": "22 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000008088472",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32751,7 +32751,7 @@
     "name": "22 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000041046917",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32783,7 +32783,7 @@
     "name": "22 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000097945999",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32799,7 +32799,7 @@
     "name": "22 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000013214057",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32815,7 +32815,7 @@
     "name": "22 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000091672539",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32847,7 +32847,7 @@
     "name": "22 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000024678943",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32863,7 +32863,7 @@
     "name": "22 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000042066730",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32879,7 +32879,7 @@
     "name": "22 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000065377101",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32895,7 +32895,7 @@
     "name": "22 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000068350387",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32911,7 +32911,7 @@
     "name": "22 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000075792503",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32927,7 +32927,7 @@
     "name": "22 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000010607606",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32943,7 +32943,7 @@
     "name": "22 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000091631429",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -32975,7 +32975,7 @@
     "name": "22 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000063901900",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33039,7 +33039,7 @@
     "name": "22 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000025410405",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33071,7 +33071,7 @@
     "name": "22 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000017181763",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33087,7 +33087,7 @@
     "name": "22 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000053164281",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33103,7 +33103,7 @@
     "name": "22 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000033908901",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33119,7 +33119,7 @@
     "name": "22 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000098272070",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33151,7 +33151,7 @@
     "name": "22 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000102211918",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33167,7 +33167,7 @@
     "name": "22 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000083106596",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33183,7 +33183,7 @@
     "name": "22 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000015963739",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33199,7 +33199,7 @@
     "name": "22 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000066406537",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33215,7 +33215,7 @@
     "name": "22 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000001511635",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33231,7 +33231,7 @@
     "name": "22 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000043820730",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33247,7 +33247,7 @@
     "name": "22 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000056951131",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33263,7 +33263,7 @@
     "name": "22 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000062319640",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33279,7 +33279,7 @@
     "name": "220 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000023319791",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33311,7 +33311,7 @@
     "name": "221 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000007181887",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33343,7 +33343,7 @@
     "name": "222 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000028992343",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33375,7 +33375,7 @@
     "name": "223 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000007294752",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33407,7 +33407,7 @@
     "name": "224 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000049692099",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33439,7 +33439,7 @@
     "name": "225 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000075174035",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33471,7 +33471,7 @@
     "name": "226 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000076957083",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33503,7 +33503,7 @@
     "name": "227 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000008772739",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33535,7 +33535,7 @@
     "name": "228 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000044018048",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33567,7 +33567,7 @@
     "name": "229 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000102799718",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33599,7 +33599,7 @@
     "name": "23 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000093943650",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33615,7 +33615,7 @@
     "name": "23 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000078396615",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33631,7 +33631,7 @@
     "name": "23 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000086877319",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33679,7 +33679,7 @@
     "name": "23 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000010090980",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33711,7 +33711,7 @@
     "name": "23 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153917117",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33727,7 +33727,7 @@
     "name": "23 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000102950830",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33743,7 +33743,7 @@
     "name": "23 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000036241885",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33759,7 +33759,7 @@
     "name": "23 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000069638089",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33807,7 +33807,7 @@
     "name": "23 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000032292899",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33855,7 +33855,7 @@
     "name": "23 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000057026440",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33919,7 +33919,7 @@
     "name": "23 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000025318733",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33935,7 +33935,7 @@
     "name": "23 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000096019367",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33951,7 +33951,7 @@
     "name": "23 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000027986517",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33967,7 +33967,7 @@
     "name": "23 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000044169971",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -33999,7 +33999,7 @@
     "name": "23 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000084531554",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34015,7 +34015,7 @@
     "name": "23 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000106207383",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34031,7 +34031,7 @@
     "name": "23 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000053123793",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34047,7 +34047,7 @@
     "name": "23 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000005018150",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34095,7 +34095,7 @@
     "name": "23 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000057458365",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34127,7 +34127,7 @@
     "name": "23 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000070802586",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34143,7 +34143,7 @@
     "name": "23 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000103691327",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34159,7 +34159,7 @@
     "name": "23 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000063095575",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34175,7 +34175,7 @@
     "name": "23 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000051887251",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34191,7 +34191,7 @@
     "name": "23 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000064451882",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34207,7 +34207,7 @@
     "name": "23 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000054378207",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34223,7 +34223,7 @@
     "name": "23 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000076615378",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34239,7 +34239,7 @@
     "name": "23 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000074849790",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34255,7 +34255,7 @@
     "name": "23 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000059589524",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34271,7 +34271,7 @@
     "name": "23 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000098588810",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34287,7 +34287,7 @@
     "name": "23 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000096003048",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34303,7 +34303,7 @@
     "name": "23 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000072032516",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34319,7 +34319,7 @@
     "name": "23 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000046914153",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34335,7 +34335,7 @@
     "name": "23 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000022151291",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34367,7 +34367,7 @@
     "name": "23 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000016787972",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34415,7 +34415,7 @@
     "name": "23 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000019281871",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34431,7 +34431,7 @@
     "name": "23 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000110137310",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34463,7 +34463,7 @@
     "name": "23 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000087495902",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34479,7 +34479,7 @@
     "name": "23 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000014143863",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34511,7 +34511,7 @@
     "name": "23 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000037323202",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34527,7 +34527,7 @@
     "name": "23 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000078152792",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34543,7 +34543,7 @@
     "name": "23 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000088356329",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34559,7 +34559,7 @@
     "name": "23 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000105111389",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34575,7 +34575,7 @@
     "name": "23 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000103891023",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34607,7 +34607,7 @@
     "name": "23 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000086848840",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34623,7 +34623,7 @@
     "name": "23 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000061306070",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34639,7 +34639,7 @@
     "name": "23 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000020911808",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34655,7 +34655,7 @@
     "name": "230 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000062216506",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34687,7 +34687,7 @@
     "name": "231 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000007438461",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34703,7 +34703,7 @@
     "name": "232 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000091676734",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34735,7 +34735,7 @@
     "name": "233 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000032221907",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34767,7 +34767,7 @@
     "name": "234 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000074885075",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34815,7 +34815,7 @@
     "name": "236 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000059571568",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34831,7 +34831,7 @@
     "name": "238 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000066558632",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34863,7 +34863,7 @@
     "name": "239 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000019067714",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34879,7 +34879,7 @@
     "name": "24 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000006577433",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34895,7 +34895,7 @@
     "name": "24 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000080333312",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34911,7 +34911,7 @@
     "name": "24 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000001491501",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -34959,7 +34959,7 @@
     "name": "24 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000153913691",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35007,7 +35007,7 @@
     "name": "24 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000045792098",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35023,7 +35023,7 @@
     "name": "24 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000096396881",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35039,7 +35039,7 @@
     "name": "24 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000098105021",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35055,7 +35055,7 @@
     "name": "24 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153917129",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35071,7 +35071,7 @@
     "name": "24 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000093493587",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35087,7 +35087,7 @@
     "name": "24 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000069219824",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35103,7 +35103,7 @@
     "name": "24 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000065355504",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35135,7 +35135,7 @@
     "name": "24 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000029105828",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35167,7 +35167,7 @@
     "name": "24 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000046081181",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35199,7 +35199,7 @@
     "name": "24 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000029969896",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35215,7 +35215,7 @@
     "name": "24 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000068274179",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35231,7 +35231,7 @@
     "name": "24 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000016294084",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35263,7 +35263,7 @@
     "name": "24 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000011373512",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35295,7 +35295,7 @@
     "name": "24 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000075539318",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35311,7 +35311,7 @@
     "name": "24 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000027194291",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35327,7 +35327,7 @@
     "name": "24 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000019750853",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35359,7 +35359,7 @@
     "name": "24 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000094876754",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35391,7 +35391,7 @@
     "name": "24 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000046283473",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35407,7 +35407,7 @@
     "name": "24 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000061254067",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35423,7 +35423,7 @@
     "name": "24 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121993335",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35455,7 +35455,7 @@
     "name": "24 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000039811314",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35487,7 +35487,7 @@
     "name": "24 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000026479835",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35519,7 +35519,7 @@
     "name": "24 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000094694958",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35535,7 +35535,7 @@
     "name": "24 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000013188192",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35551,7 +35551,7 @@
     "name": "24 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000075082055",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35583,7 +35583,7 @@
     "name": "24 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000055514494",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35599,7 +35599,7 @@
     "name": "24 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000080767760",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35615,7 +35615,7 @@
     "name": "24 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000055062967",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35631,7 +35631,7 @@
     "name": "24 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000035486333",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35647,7 +35647,7 @@
     "name": "24 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000045346033",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35679,7 +35679,7 @@
     "name": "24 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000054440878",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35743,7 +35743,7 @@
     "name": "24 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000066361756",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35775,7 +35775,7 @@
     "name": "24 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000109894466",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35791,7 +35791,7 @@
     "name": "24 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000098196570",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35807,7 +35807,7 @@
     "name": "24 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000101607514",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35823,7 +35823,7 @@
     "name": "24 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000070994372",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35839,7 +35839,7 @@
     "name": "24 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000089539287",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35855,7 +35855,7 @@
     "name": "24 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000007423306",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35871,7 +35871,7 @@
     "name": "24 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000076239313",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35903,7 +35903,7 @@
     "name": "24 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000057167550",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35919,7 +35919,7 @@
     "name": "24 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000065447786",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35935,7 +35935,7 @@
     "name": "24 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000099753499",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35951,7 +35951,7 @@
     "name": "240 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000102045992",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35983,7 +35983,7 @@
     "name": "241 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000090648269",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -35999,7 +35999,7 @@
     "name": "242 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000070572938",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36031,7 +36031,7 @@
     "name": "243 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000032160583",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36047,7 +36047,7 @@
     "name": "244 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000053282030",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36079,7 +36079,7 @@
     "name": "246 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000001578027",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36111,7 +36111,7 @@
     "name": "247 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000006245423",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36127,7 +36127,7 @@
     "name": "248 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000062318495",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36159,7 +36159,7 @@
     "name": "249 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000013923166",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36191,7 +36191,7 @@
     "name": "24A WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000100076146",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36207,7 +36207,7 @@
     "name": "25 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000061617677",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36223,7 +36223,7 @@
     "name": "25 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000017919136",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36239,7 +36239,7 @@
     "name": "25 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000061347277",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36287,7 +36287,7 @@
     "name": "25 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000063742402",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36319,7 +36319,7 @@
     "name": "25 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153917138",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36335,7 +36335,7 @@
     "name": "25 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000007295127",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36351,7 +36351,7 @@
     "name": "25 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000017167844",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36367,7 +36367,7 @@
     "name": "25 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000079633679",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36399,7 +36399,7 @@
     "name": "25 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000058399771",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36431,7 +36431,7 @@
     "name": "25 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000015551844",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36463,7 +36463,7 @@
     "name": "25 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000063224678",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36527,7 +36527,7 @@
     "name": "25 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000101628324",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36543,7 +36543,7 @@
     "name": "25 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000108332012",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36559,7 +36559,7 @@
     "name": "25 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000109890144",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36591,7 +36591,7 @@
     "name": "25 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000057628233",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36607,7 +36607,7 @@
     "name": "25 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000025055974",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36623,7 +36623,7 @@
     "name": "25 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000025577748",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36639,7 +36639,7 @@
     "name": "25 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121993342",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36671,7 +36671,7 @@
     "name": "25 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000012264830",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36703,7 +36703,7 @@
     "name": "25 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000087922183",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36719,7 +36719,7 @@
     "name": "25 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000054469484",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36735,7 +36735,7 @@
     "name": "25 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000031691473",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36751,7 +36751,7 @@
     "name": "25 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000022176974",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36767,7 +36767,7 @@
     "name": "25 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000100344076",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36783,7 +36783,7 @@
     "name": "25 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000097641123",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36799,7 +36799,7 @@
     "name": "25 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000090644365",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36815,7 +36815,7 @@
     "name": "25 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000088542530",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36831,7 +36831,7 @@
     "name": "25 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000003941625",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36847,7 +36847,7 @@
     "name": "25 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000072705224",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36863,7 +36863,7 @@
     "name": "25 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000102718283",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36879,7 +36879,7 @@
     "name": "25 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000018853348",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36895,7 +36895,7 @@
     "name": "25 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000078824277",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36975,7 +36975,7 @@
     "name": "25 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000046254751",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -36991,7 +36991,7 @@
     "name": "25 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000099779282",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37007,7 +37007,7 @@
     "name": "25 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000097950825",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37023,7 +37023,7 @@
     "name": "25 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000008960011",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37039,7 +37039,7 @@
     "name": "25 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000107805181",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37071,7 +37071,7 @@
     "name": "25 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000098827706",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37087,7 +37087,7 @@
     "name": "25 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000053395141",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37119,7 +37119,7 @@
     "name": "25 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000024651113",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37135,7 +37135,7 @@
     "name": "25 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000052762720",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37167,7 +37167,7 @@
     "name": "25 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000042749389",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37183,7 +37183,7 @@
     "name": "25 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000026846572",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37199,7 +37199,7 @@
     "name": "250 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000098646333",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37231,7 +37231,7 @@
     "name": "251 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000064369554",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37247,7 +37247,7 @@
     "name": "252 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000080030285",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37279,7 +37279,7 @@
     "name": "253 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000040949534",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37295,7 +37295,7 @@
     "name": "254 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000005605898",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37327,7 +37327,7 @@
     "name": "255 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000009736648",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37343,7 +37343,7 @@
     "name": "256 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000109603736",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37375,7 +37375,7 @@
     "name": "257 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000012412827",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37391,7 +37391,7 @@
     "name": "258 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000073740303",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37423,7 +37423,7 @@
     "name": "259 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000065054886",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37439,7 +37439,7 @@
     "name": "25A CASINO STREET GLENWOOD 2768",
     "locID": "LOC000079886900",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37455,7 +37455,7 @@
     "name": "25B CASINO STREET GLENWOOD 2768",
     "locID": "LOC000079633679",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37471,7 +37471,7 @@
     "name": "26 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000064183881",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37535,7 +37535,7 @@
     "name": "26 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000153914533",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37567,7 +37567,7 @@
     "name": "26 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000078128830",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37583,7 +37583,7 @@
     "name": "26 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000021431401",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37599,7 +37599,7 @@
     "name": "26 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000109712833",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37631,7 +37631,7 @@
     "name": "26 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000098519456",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37647,7 +37647,7 @@
     "name": "26 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000085281010",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37663,7 +37663,7 @@
     "name": "26 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000104051314",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37711,7 +37711,7 @@
     "name": "26 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000005507574",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37743,7 +37743,7 @@
     "name": "26 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000083091256",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37775,7 +37775,7 @@
     "name": "26 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000070663287",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37791,7 +37791,7 @@
     "name": "26 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000076745150",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37807,7 +37807,7 @@
     "name": "26 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000008208990",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37839,7 +37839,7 @@
     "name": "26 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000057962731",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37871,7 +37871,7 @@
     "name": "26 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000062360667",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37887,7 +37887,7 @@
     "name": "26 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000033951256",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37903,7 +37903,7 @@
     "name": "26 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000063420427",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37935,7 +37935,7 @@
     "name": "26 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000035446970",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37951,7 +37951,7 @@
     "name": "26 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000043857652",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37967,7 +37967,7 @@
     "name": "26 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000023820386",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -37983,7 +37983,7 @@
     "name": "26 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121993357",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38015,7 +38015,7 @@
     "name": "26 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000078052006",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38063,7 +38063,7 @@
     "name": "26 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000078300017",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38095,7 +38095,7 @@
     "name": "26 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000096520750",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38111,7 +38111,7 @@
     "name": "26 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000019686786",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38127,7 +38127,7 @@
     "name": "26 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000004051735",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38159,7 +38159,7 @@
     "name": "26 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000054543585",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38175,7 +38175,7 @@
     "name": "26 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000016381225",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38191,7 +38191,7 @@
     "name": "26 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000065166953",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38207,7 +38207,7 @@
     "name": "26 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000067603605",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38239,7 +38239,7 @@
     "name": "26 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000053940876",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38303,7 +38303,7 @@
     "name": "26 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000066626755",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38335,7 +38335,7 @@
     "name": "26 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000062796219",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38351,7 +38351,7 @@
     "name": "26 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000007230836",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38367,7 +38367,7 @@
     "name": "26 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000068169900",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38383,7 +38383,7 @@
     "name": "26 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000101595155",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38399,7 +38399,7 @@
     "name": "26 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000010622852",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38415,7 +38415,7 @@
     "name": "26 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000100922874",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38431,7 +38431,7 @@
     "name": "26 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000011534106",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38463,7 +38463,7 @@
     "name": "26 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000012364687",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38495,7 +38495,7 @@
     "name": "261 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000102181605",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38511,7 +38511,7 @@
     "name": "262 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000031319433",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38543,7 +38543,7 @@
     "name": "263 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000014007640",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38559,7 +38559,7 @@
     "name": "264 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000043816710",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38591,7 +38591,7 @@
     "name": "265 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000063271526",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38607,7 +38607,7 @@
     "name": "266 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000086415072",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38639,7 +38639,7 @@
     "name": "267 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000028687870",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38655,7 +38655,7 @@
     "name": "268 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000001403871",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38687,7 +38687,7 @@
     "name": "269 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000019710559",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38703,7 +38703,7 @@
     "name": "26A HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000035375659",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38719,7 +38719,7 @@
     "name": "27 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000049670620",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38735,7 +38735,7 @@
     "name": "27 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000089734732",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38783,7 +38783,7 @@
     "name": "27 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000004685465",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38815,7 +38815,7 @@
     "name": "27 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153917164",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38831,7 +38831,7 @@
     "name": "27 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000033124935",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38847,7 +38847,7 @@
     "name": "27 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000025362258",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38895,7 +38895,7 @@
     "name": "27 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000043383096",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38927,7 +38927,7 @@
     "name": "27 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000053028401",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38975,7 +38975,7 @@
     "name": "27 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000019598216",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -38991,7 +38991,7 @@
     "name": "27 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000084269071",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39007,7 +39007,7 @@
     "name": "27 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000010001407",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39039,7 +39039,7 @@
     "name": "27 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000031209563",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39055,7 +39055,7 @@
     "name": "27 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000013994292",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39071,7 +39071,7 @@
     "name": "27 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121993361",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39103,7 +39103,7 @@
     "name": "27 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000065244426",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39135,7 +39135,7 @@
     "name": "27 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000036396948",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39151,7 +39151,7 @@
     "name": "27 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000093013512",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39167,7 +39167,7 @@
     "name": "27 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000022364912",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39183,7 +39183,7 @@
     "name": "27 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000003943282",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39199,7 +39199,7 @@
     "name": "27 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000025541726",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39215,7 +39215,7 @@
     "name": "27 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000015803520",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39231,7 +39231,7 @@
     "name": "27 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000107347820",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39247,7 +39247,7 @@
     "name": "27 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000090172701",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39263,7 +39263,7 @@
     "name": "27 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000042082383",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39279,7 +39279,7 @@
     "name": "27 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000099580488",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39295,7 +39295,7 @@
     "name": "27 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000069930680",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39327,7 +39327,7 @@
     "name": "27 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000062087018",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39375,7 +39375,7 @@
     "name": "27 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000029093610",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39391,7 +39391,7 @@
     "name": "27 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000045330104",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39407,7 +39407,7 @@
     "name": "27 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000031877666",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39423,7 +39423,7 @@
     "name": "27 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000053901598",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39439,7 +39439,7 @@
     "name": "27 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000046082119",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39455,7 +39455,7 @@
     "name": "27 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000017993834",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39471,7 +39471,7 @@
     "name": "27 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000051789582",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39487,7 +39487,7 @@
     "name": "27 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000006339781",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39503,7 +39503,7 @@
     "name": "27 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000060145239",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39535,7 +39535,7 @@
     "name": "27 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000017242529",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39551,7 +39551,7 @@
     "name": "27 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000044175777",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39567,7 +39567,7 @@
     "name": "270 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000005969097",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39583,7 +39583,7 @@
     "name": "271 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000074006512",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39599,7 +39599,7 @@
     "name": "272 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000034684208",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39615,7 +39615,7 @@
     "name": "273 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000007188947",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39631,7 +39631,7 @@
     "name": "274 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000027217739",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39663,7 +39663,7 @@
     "name": "276 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000045327287",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39679,7 +39679,7 @@
     "name": "277 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000023946554",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39695,7 +39695,7 @@
     "name": "278 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000088009266",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39711,7 +39711,7 @@
     "name": "279 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000089914023",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39727,7 +39727,7 @@
     "name": "27A THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000051789582",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39743,7 +39743,7 @@
     "name": "27A WARDIA STREET GLENWOOD 2768",
     "locID": "LOC100081098580",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39759,7 +39759,7 @@
     "name": "27B THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000051597455",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39775,7 +39775,7 @@
     "name": "28 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000054023399",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39791,7 +39791,7 @@
     "name": "28 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000101270713",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39855,7 +39855,7 @@
     "name": "28 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000029180809",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39871,7 +39871,7 @@
     "name": "28 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153917172",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39887,7 +39887,7 @@
     "name": "28 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000105080806",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39903,7 +39903,7 @@
     "name": "28 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000027883273",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39919,7 +39919,7 @@
     "name": "28 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000012174021",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39951,7 +39951,7 @@
     "name": "28 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000034094938",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39967,7 +39967,7 @@
     "name": "28 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000022368283",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -39999,7 +39999,7 @@
     "name": "28 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000029969896",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40015,7 +40015,7 @@
     "name": "28 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000093626285",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40031,7 +40031,7 @@
     "name": "28 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000092075249",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40095,7 +40095,7 @@
     "name": "28 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000023762364",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40111,7 +40111,7 @@
     "name": "28 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000035091285",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40127,7 +40127,7 @@
     "name": "28 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000055800994",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40159,7 +40159,7 @@
     "name": "28 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000053531134",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40175,7 +40175,7 @@
     "name": "28 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000094825995",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40191,7 +40191,7 @@
     "name": "28 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121993414",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40223,7 +40223,7 @@
     "name": "28 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000101931995",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40271,7 +40271,7 @@
     "name": "28 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000096622247",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40303,7 +40303,7 @@
     "name": "28 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000095447265",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40319,7 +40319,7 @@
     "name": "28 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000068807150",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40335,7 +40335,7 @@
     "name": "28 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000004672083",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40351,7 +40351,7 @@
     "name": "28 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000086250497",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40367,7 +40367,7 @@
     "name": "28 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000099726411",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40383,7 +40383,7 @@
     "name": "28 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000078218806",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40415,7 +40415,7 @@
     "name": "28 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000057862283",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40479,7 +40479,7 @@
     "name": "28 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000067881478",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40511,7 +40511,7 @@
     "name": "28 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000036984615",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40527,7 +40527,7 @@
     "name": "28 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000010868398",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40543,7 +40543,7 @@
     "name": "28 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000081179054",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40559,7 +40559,7 @@
     "name": "28 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000068128604",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40575,7 +40575,7 @@
     "name": "28 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000015023579",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40591,7 +40591,7 @@
     "name": "28 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000053120654",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40607,7 +40607,7 @@
     "name": "28 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000055974749",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40639,7 +40639,7 @@
     "name": "28 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000023693593",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40671,7 +40671,7 @@
     "name": "281 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000038154691",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40687,7 +40687,7 @@
     "name": "282 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000105372163",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40703,7 +40703,7 @@
     "name": "284 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000008737146",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40719,7 +40719,7 @@
     "name": "286 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000090275019",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40735,7 +40735,7 @@
     "name": "288 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000033190315",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40751,7 +40751,7 @@
     "name": "28A BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000105372768",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40783,7 +40783,7 @@
     "name": "28A WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000023773977",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40815,7 +40815,7 @@
     "name": "29 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000097844353",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40831,7 +40831,7 @@
     "name": "29 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000066570608",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40879,7 +40879,7 @@
     "name": "29 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000086929654",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40895,7 +40895,7 @@
     "name": "29 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153917186",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40911,7 +40911,7 @@
     "name": "29 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000094834110",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40927,7 +40927,7 @@
     "name": "29 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000057211124",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -40975,7 +40975,7 @@
     "name": "29 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000029541352",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41007,7 +41007,7 @@
     "name": "29 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000067559788",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41055,7 +41055,7 @@
     "name": "29 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000079899762",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41071,7 +41071,7 @@
     "name": "29 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000098343297",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41087,7 +41087,7 @@
     "name": "29 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000019670999",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41119,7 +41119,7 @@
     "name": "29 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000023110585",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41135,7 +41135,7 @@
     "name": "29 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000043935516",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41167,7 +41167,7 @@
     "name": "29 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000030433333",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41199,7 +41199,7 @@
     "name": "29 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000101947692",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41231,7 +41231,7 @@
     "name": "29 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000067340569",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41263,7 +41263,7 @@
     "name": "29 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000006431830",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41279,7 +41279,7 @@
     "name": "29 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000102479658",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41295,7 +41295,7 @@
     "name": "29 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000083102355",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41311,7 +41311,7 @@
     "name": "29 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000023234911",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41327,7 +41327,7 @@
     "name": "29 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000088337784",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41375,7 +41375,7 @@
     "name": "29 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000042007408",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41391,7 +41391,7 @@
     "name": "29 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000021368004",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41407,7 +41407,7 @@
     "name": "29 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000091367187",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41423,7 +41423,7 @@
     "name": "29 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000051560970",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41439,7 +41439,7 @@
     "name": "29 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000105138284",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41487,7 +41487,7 @@
     "name": "29 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000065116755",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41503,7 +41503,7 @@
     "name": "29 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000072213604",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41533,9 +41533,9 @@
    },
    "properties": {
     "name": "29 WILLOWTREE AVENUE GLENWOOD 2768",
-    "locID": "LOC000063729730",
+    "locID": "LOC000154702038",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41551,7 +41551,7 @@
     "name": "29 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000082417580",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41567,7 +41567,7 @@
     "name": "290 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000035921517",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41583,7 +41583,7 @@
     "name": "292 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000046508634",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41599,7 +41599,7 @@
     "name": "294 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000090573925",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41615,7 +41615,7 @@
     "name": "296 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000079840838",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41647,7 +41647,7 @@
     "name": "298 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000021607142",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41711,7 +41711,7 @@
     "name": "3 ABDALE CRESCENT GLENWOOD 2768",
     "locID": "LOC000002206278",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41727,7 +41727,7 @@
     "name": "3 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000010941058",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41743,7 +41743,7 @@
     "name": "3 AGINCOURT PLACE GLENWOOD 2768",
     "locID": "LOC000009163126",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41759,7 +41759,7 @@
     "name": "3 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000002990361",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41775,7 +41775,7 @@
     "name": "3 ALMONA STREET GLENWOOD 2768",
     "locID": "LOC000055635108",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41791,7 +41791,7 @@
     "name": "3 ALPINE WAY GLENWOOD 2768",
     "locID": "LOC000062046641",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41807,7 +41807,7 @@
     "name": "3 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000040367133",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41823,7 +41823,7 @@
     "name": "3 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000053271418",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41839,7 +41839,7 @@
     "name": "3 AMUET PLACE GLENWOOD 2768",
     "locID": "LOC000045476516",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41871,7 +41871,7 @@
     "name": "3 ANGEL COURT GLENWOOD 2768",
     "locID": "LOC000031279461",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41887,7 +41887,7 @@
     "name": "3 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000086185923",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41903,7 +41903,7 @@
     "name": "3 ANITA STREET GLENWOOD 2768",
     "locID": "LOC000102496661",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41935,7 +41935,7 @@
     "name": "3 ARNIKA COURT GLENWOOD 2768",
     "locID": "LOC000121993433",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -41983,7 +41983,7 @@
     "name": "3 AVRIL COURT GLENWOOD 2768",
     "locID": "LOC000091775176",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42031,7 +42031,7 @@
     "name": "3 BAIL WAY GLENWOOD 2768",
     "locID": "LOC000090000492",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42047,7 +42047,7 @@
     "name": "3 BARBER PLACE GLENWOOD 2768",
     "locID": "LOC000076149669",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42063,7 +42063,7 @@
     "name": "3 BEAUMONT AVENUE GLENWOOD 2768",
     "locID": "LOC000058939295",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42079,7 +42079,7 @@
     "name": "3 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000033046518",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42095,7 +42095,7 @@
     "name": "3 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000046667007",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42111,7 +42111,7 @@
     "name": "3 BETH WAY GLENWOOD 2768",
     "locID": "LOC000074531592",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42143,7 +42143,7 @@
     "name": "3 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000010529628",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42159,7 +42159,7 @@
     "name": "3 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000076846459",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42191,7 +42191,7 @@
     "name": "3 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000039561913",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42207,7 +42207,7 @@
     "name": "3 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000078864664",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42223,7 +42223,7 @@
     "name": "3 BRONTE AVENUE GLENWOOD 2768",
     "locID": "LOC000050162375",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42239,7 +42239,7 @@
     "name": "3 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000080943667",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42255,7 +42255,7 @@
     "name": "3 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000110015477",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42271,7 +42271,7 @@
     "name": "3 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000062115322",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42287,7 +42287,7 @@
     "name": "3 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000081307397",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42303,7 +42303,7 @@
     "name": "3 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000077420310",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42335,7 +42335,7 @@
     "name": "3 CAROONA WAY GLENWOOD 2768",
     "locID": "LOC000030827808",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42351,7 +42351,7 @@
     "name": "3 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000052209083",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42367,7 +42367,7 @@
     "name": "3 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000053263246",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42415,7 +42415,7 @@
     "name": "3 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000080847577",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42479,7 +42479,7 @@
     "name": "3 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000043951151",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42495,7 +42495,7 @@
     "name": "3 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000072205853",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42511,7 +42511,7 @@
     "name": "3 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000004744084",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42559,7 +42559,7 @@
     "name": "3 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000043172695",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42575,7 +42575,7 @@
     "name": "3 DARREN COURT GLENWOOD 2768",
     "locID": "LOC000040461195",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42591,7 +42591,7 @@
     "name": "3 DEAKIN AVENUE GLENWOOD 2768",
     "locID": "LOC000013103842",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42607,7 +42607,7 @@
     "name": "3 DENMAN COURT GLENWOOD 2768",
     "locID": "LOC000017172162",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42623,7 +42623,7 @@
     "name": "3 DIENELT CLOSE GLENWOOD 2768",
     "locID": "LOC000045839178",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42639,7 +42639,7 @@
     "name": "3 EAGLE WAY GLENWOOD 2768",
     "locID": "LOC000065371267",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42687,7 +42687,7 @@
     "name": "3 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000013188159",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42719,7 +42719,7 @@
     "name": "3 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000043789740",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42767,7 +42767,7 @@
     "name": "3 EUREKA GROVE GLENWOOD 2768",
     "locID": "LOC000041817820",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42799,7 +42799,7 @@
     "name": "3 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000038069659",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42815,7 +42815,7 @@
     "name": "3 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000049583281",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42847,7 +42847,7 @@
     "name": "3 FIG TERRACE GLENWOOD 2768",
     "locID": "LOC000010003576",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42863,7 +42863,7 @@
     "name": "3 FINCH PLACE GLENWOOD 2768",
     "locID": "LOC000039108748",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42895,7 +42895,7 @@
     "name": "3 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000057327945",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42911,7 +42911,7 @@
     "name": "3 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000060944508",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42927,7 +42927,7 @@
     "name": "3 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000014107367",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42943,7 +42943,7 @@
     "name": "3 GARNET GROVE GLENWOOD 2768",
     "locID": "LOC000067978797",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -42991,7 +42991,7 @@
     "name": "3 GLENLEA COURT GLENWOOD 2768",
     "locID": "LOC000014586564",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43039,7 +43039,7 @@
     "name": "3 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000076762967",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43055,7 +43055,7 @@
     "name": "3 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000013032337",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43103,7 +43103,7 @@
     "name": "3 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000061518608",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43119,7 +43119,7 @@
     "name": "3 HAMBRO AVENUE GLENWOOD 2768",
     "locID": "LOC000065505180",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43135,7 +43135,7 @@
     "name": "3 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000069164740",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43151,7 +43151,7 @@
     "name": "3 HERITAGE PLACE GLENWOOD 2768",
     "locID": "LOC000022009072",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43183,7 +43183,7 @@
     "name": "3 HONEYEATER TERRACE GLENWOOD 2768",
     "locID": "LOC000074928081",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43199,7 +43199,7 @@
     "name": "3 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000017190310",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43231,7 +43231,7 @@
     "name": "3 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121993451",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43263,7 +43263,7 @@
     "name": "3 JOYCE STREET GLENWOOD 2768",
     "locID": "LOC000007319578",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43279,7 +43279,7 @@
     "name": "3 KANDOS STREET GLENWOOD 2768",
     "locID": "LOC000088144486",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43295,7 +43295,7 @@
     "name": "3 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000106055828",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43327,7 +43327,7 @@
     "name": "3 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000003067545",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43359,7 +43359,7 @@
     "name": "3 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000187050325",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43375,7 +43375,7 @@
     "name": "3 KOOKABURRA GROVE GLENWOOD 2768",
     "locID": "LOC000087046119",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43407,7 +43407,7 @@
     "name": "3 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000018451716",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43423,7 +43423,7 @@
     "name": "3 KYALITE STREET GLENWOOD 2768",
     "locID": "LOC000006480496",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43439,7 +43439,7 @@
     "name": "3 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000011302749",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43455,7 +43455,7 @@
     "name": "3 LEMON GROVE GLENWOOD 2768",
     "locID": "LOC000002169502",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43487,7 +43487,7 @@
     "name": "3 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000020989605",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43503,7 +43503,7 @@
     "name": "3 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000075810254",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43519,7 +43519,7 @@
     "name": "3 MAGPIE COURT GLENWOOD 2768",
     "locID": "LOC000121996538",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43551,7 +43551,7 @@
     "name": "3 MALEY GROVE GLENWOOD 2768",
     "locID": "LOC000052035821",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43567,7 +43567,7 @@
     "name": "3 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000153932624",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43583,7 +43583,7 @@
     "name": "3 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000029151466",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43599,7 +43599,7 @@
     "name": "3 MARS WAY GLENWOOD 2768",
     "locID": "LOC000009855276",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43615,7 +43615,7 @@
     "name": "3 MATARA WAY GLENWOOD 2768",
     "locID": "LOC000105507481",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43631,7 +43631,7 @@
     "name": "3 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000025955257",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43647,7 +43647,7 @@
     "name": "3 MCMAHON GROVE GLENWOOD 2768",
     "locID": "LOC000018403160",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43679,7 +43679,7 @@
     "name": "3 MIAMI STREET GLENWOOD 2768",
     "locID": "LOC000070462337",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43695,7 +43695,7 @@
     "name": "3 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000028950500",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43711,7 +43711,7 @@
     "name": "3 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000044071409",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43727,7 +43727,7 @@
     "name": "3 MINUET COURT GLENWOOD 2768",
     "locID": "LOC000013972460",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43775,7 +43775,7 @@
     "name": "3 MUSCAT GROVE GLENWOOD 2768",
     "locID": "LOC000038299118",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43791,7 +43791,7 @@
     "name": "3 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000109205024",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43807,7 +43807,7 @@
     "name": "3 NESH PLACE GLENWOOD 2768",
     "locID": "LOC000121996540",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43823,7 +43823,7 @@
     "name": "3 NEWNES CLOSE GLENWOOD 2768",
     "locID": "LOC000002294263",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43839,7 +43839,7 @@
     "name": "3 NIXON STREET GLENWOOD 2768",
     "locID": "LOC000006423243",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43855,7 +43855,7 @@
     "name": "3 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000043203012",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43871,7 +43871,7 @@
     "name": "3 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000052614619",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43887,7 +43887,7 @@
     "name": "3 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000075805932",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43903,7 +43903,7 @@
     "name": "3 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000093485462",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43919,7 +43919,7 @@
     "name": "3 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000086896762",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43935,7 +43935,7 @@
     "name": "3 PEACH GARDENS GLENWOOD 2768",
     "locID": "LOC000033269150",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43951,7 +43951,7 @@
     "name": "3 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000084041921",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43983,7 +43983,7 @@
     "name": "3 PERIDOT PLACE GLENWOOD 2768",
     "locID": "LOC000076863969",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -43999,7 +43999,7 @@
     "name": "3 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000044023048",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44047,7 +44047,7 @@
     "name": "3 PINNACLE WAY GLENWOOD 2768",
     "locID": "LOC000053996759",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44063,7 +44063,7 @@
     "name": "3 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000038128991",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44079,7 +44079,7 @@
     "name": "3 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000071216828",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44095,7 +44095,7 @@
     "name": "3 POPPY WAY GLENWOOD 2768",
     "locID": "LOC000121996555",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44111,7 +44111,7 @@
     "name": "3 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000005619418",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44143,7 +44143,7 @@
     "name": "3 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000077377587",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44175,7 +44175,7 @@
     "name": "3 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000114236066",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44207,7 +44207,7 @@
     "name": "3 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000043813496",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44223,7 +44223,7 @@
     "name": "3 RYDER STREET GLENWOOD 2768",
     "locID": "LOC000052010605",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44271,7 +44271,7 @@
     "name": "3 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000054608760",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44287,7 +44287,7 @@
     "name": "3 SENTINEL STREET GLENWOOD 2768",
     "locID": "LOC000041034109",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44303,7 +44303,7 @@
     "name": "3 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000087447025",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44319,7 +44319,7 @@
     "name": "3 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000014082149",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44335,7 +44335,7 @@
     "name": "3 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000110091188",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44383,7 +44383,7 @@
     "name": "3 SOLAR PLACE GLENWOOD 2768",
     "locID": "LOC000084059808",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44399,7 +44399,7 @@
     "name": "3 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000093398971",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44415,7 +44415,7 @@
     "name": "3 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000077611691",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44447,7 +44447,7 @@
     "name": "3 STRAWBERRY WAY GLENWOOD 2768",
     "locID": "LOC000023030100",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44463,7 +44463,7 @@
     "name": "3 SULTANA GROVE GLENWOOD 2768",
     "locID": "LOC000052132930",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44479,7 +44479,7 @@
     "name": "3 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000073180958",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44495,7 +44495,7 @@
     "name": "3 SWANSEA COURT GLENWOOD 2768",
     "locID": "LOC000114806918",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44527,7 +44527,7 @@
     "name": "3 TANN-DARBY COURT GLENWOOD 2768",
     "locID": "LOC000017459974",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44543,7 +44543,7 @@
     "name": "3 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000099274679",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44559,7 +44559,7 @@
     "name": "3 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000053538162",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44575,7 +44575,7 @@
     "name": "3 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000113174323",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44591,7 +44591,7 @@
     "name": "3 WALTHAM WAY GLENWOOD 2768",
     "locID": "LOC000077395320",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44607,7 +44607,7 @@
     "name": "3 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000058707617",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44623,7 +44623,7 @@
     "name": "3 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000035532885",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44655,7 +44655,7 @@
     "name": "3 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000091283714",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44671,7 +44671,7 @@
     "name": "3 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000040292632",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44687,7 +44687,7 @@
     "name": "3 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000046539988",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44703,7 +44703,7 @@
     "name": "3 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000045026607",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44719,7 +44719,7 @@
     "name": "3 WILLOWLEAF CLOSE GLENWOOD 2768",
     "locID": "LOC000049378068",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44735,7 +44735,7 @@
     "name": "3 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000052568417",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44751,7 +44751,7 @@
     "name": "3 YANCO GLEN GLENWOOD 2768",
     "locID": "LOC000018137159",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44783,7 +44783,7 @@
     "name": "3 ZENITH COURT GLENWOOD 2768",
     "locID": "LOC000063531483",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44799,7 +44799,7 @@
     "name": "30 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000079977380",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44847,7 +44847,7 @@
     "name": "30 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000099959895",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44863,7 +44863,7 @@
     "name": "30 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153917193",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44879,7 +44879,7 @@
     "name": "30 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000110191472",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44895,7 +44895,7 @@
     "name": "30 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000064747931",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44911,7 +44911,7 @@
     "name": "30 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000077199472",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44959,7 +44959,7 @@
     "name": "30 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000082184276",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44975,7 +44975,7 @@
     "name": "30 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000078750262",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -44991,7 +44991,7 @@
     "name": "30 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000090506332",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45055,7 +45055,7 @@
     "name": "30 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000073171096",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45071,7 +45071,7 @@
     "name": "30 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000068492415",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45087,7 +45087,7 @@
     "name": "30 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000076937944",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45119,7 +45119,7 @@
     "name": "30 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000045097826",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45135,7 +45135,7 @@
     "name": "30 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000032988247",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45151,7 +45151,7 @@
     "name": "30 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121996564",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45183,7 +45183,7 @@
     "name": "30 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000074485443",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45215,7 +45215,7 @@
     "name": "30 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000061277080",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45247,7 +45247,7 @@
     "name": "30 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000090348356",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45263,7 +45263,7 @@
     "name": "30 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000090819498",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45279,7 +45279,7 @@
     "name": "30 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000039479004",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45295,7 +45295,7 @@
     "name": "30 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000098954807",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45311,7 +45311,7 @@
     "name": "30 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000009607982",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45327,7 +45327,7 @@
     "name": "30 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000093789991",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45359,7 +45359,7 @@
     "name": "30 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000057477208",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45407,7 +45407,7 @@
     "name": "30 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000032397362",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45423,7 +45423,7 @@
     "name": "30 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000011380742",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45439,7 +45439,7 @@
     "name": "30 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000020609423",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45455,7 +45455,7 @@
     "name": "30 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000043600558",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45471,7 +45471,7 @@
     "name": "30 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000024968553",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45503,7 +45503,7 @@
     "name": "30 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000109652607",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45519,7 +45519,7 @@
     "name": "300 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000004851216",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45583,7 +45583,7 @@
     "name": "304 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000033965483",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45615,7 +45615,7 @@
     "name": "306 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000032938394",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45679,7 +45679,7 @@
     "name": "30A BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000110015477",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45695,7 +45695,7 @@
     "name": "30A MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000009607982",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45727,7 +45727,7 @@
     "name": "30B MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000009655809",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45759,7 +45759,7 @@
     "name": "31 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000097697386",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45807,7 +45807,7 @@
     "name": "31 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000086049276",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45823,7 +45823,7 @@
     "name": "31 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153917206",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45839,7 +45839,7 @@
     "name": "31 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000071147916",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45855,7 +45855,7 @@
     "name": "31 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000107342856",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45903,7 +45903,7 @@
     "name": "31 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000036405181",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45935,7 +45935,7 @@
     "name": "31 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000107390443",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45967,7 +45967,7 @@
     "name": "31 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000012217979",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45983,7 +45983,7 @@
     "name": "31 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000074518481",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -45999,7 +45999,7 @@
     "name": "31 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000074564657",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46031,7 +46031,7 @@
     "name": "31 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000036525260",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46047,7 +46047,7 @@
     "name": "31 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000015971667",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46079,7 +46079,7 @@
     "name": "31 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000046592847",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46111,7 +46111,7 @@
     "name": "31 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000088464190",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46143,7 +46143,7 @@
     "name": "31 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000067334427",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46159,7 +46159,7 @@
     "name": "31 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000024577289",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46175,7 +46175,7 @@
     "name": "31 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000010540963",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46191,7 +46191,7 @@
     "name": "31 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000087396393",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46207,7 +46207,7 @@
     "name": "31 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000078426513",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46223,7 +46223,7 @@
     "name": "31 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000084041921",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46239,7 +46239,7 @@
     "name": "31 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000073549409",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46255,7 +46255,7 @@
     "name": "31 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000005599178",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46271,7 +46271,7 @@
     "name": "31 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000103983486",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46287,7 +46287,7 @@
     "name": "31 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000052791369",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46303,7 +46303,7 @@
     "name": "31 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000064330781",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46335,7 +46335,7 @@
     "name": "31 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000027326197",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46351,7 +46351,7 @@
     "name": "31 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000046514280",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46367,7 +46367,7 @@
     "name": "31-33 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000024782428",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46543,7 +46543,7 @@
     "name": "31A CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000071259998",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46575,7 +46575,7 @@
     "name": "32 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000025350122",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46623,7 +46623,7 @@
     "name": "32 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000001580005",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46639,7 +46639,7 @@
     "name": "32 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000047813244",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46655,7 +46655,7 @@
     "name": "32 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000038154689",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46719,7 +46719,7 @@
     "name": "32 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000097060952",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46735,7 +46735,7 @@
     "name": "32 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000017116134",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46751,7 +46751,7 @@
     "name": "32 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000064931483",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46815,7 +46815,7 @@
     "name": "32 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000055769377",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46831,7 +46831,7 @@
     "name": "32 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000004661472",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46847,7 +46847,7 @@
     "name": "32 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000064810715",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46879,7 +46879,7 @@
     "name": "32 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000017190310",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46911,7 +46911,7 @@
     "name": "32 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000070035454",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46943,7 +46943,7 @@
     "name": "32 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000053403947",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46959,7 +46959,7 @@
     "name": "32 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000004637448",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46975,7 +46975,7 @@
     "name": "32 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000048360106",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -46991,7 +46991,7 @@
     "name": "32 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000078543901",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47007,7 +47007,7 @@
     "name": "32 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000009687501",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47023,7 +47023,7 @@
     "name": "32 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000171076609",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47039,7 +47039,7 @@
     "name": "32 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000015009315",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47055,7 +47055,7 @@
     "name": "32 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000106252564",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47103,7 +47103,7 @@
     "name": "32 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000100054214",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47135,7 +47135,7 @@
     "name": "32 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000055937309",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47151,7 +47151,7 @@
     "name": "32 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000067663800",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47167,7 +47167,7 @@
     "name": "32 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000030516430",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47183,7 +47183,7 @@
     "name": "32 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000103685990",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47199,7 +47199,7 @@
     "name": "32 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000054105387",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47231,7 +47231,7 @@
     "name": "32 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000018714119",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47375,7 +47375,7 @@
     "name": "32A MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000062293026",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47391,7 +47391,7 @@
     "name": "32A WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000018957230",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47407,7 +47407,7 @@
     "name": "33 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000029733619",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47455,7 +47455,7 @@
     "name": "33 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000019664335",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47471,7 +47471,7 @@
     "name": "33 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000065215056",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47519,7 +47519,7 @@
     "name": "33 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000065069507",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47551,7 +47551,7 @@
     "name": "33 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000097812933",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47567,7 +47567,7 @@
     "name": "33 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000070786987",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47615,7 +47615,7 @@
     "name": "33 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000041627532",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47631,7 +47631,7 @@
     "name": "33 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000081495470",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47663,7 +47663,7 @@
     "name": "33 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000076805484",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47679,7 +47679,7 @@
     "name": "33 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000036291424",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47727,7 +47727,7 @@
     "name": "33 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000036186127",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47759,7 +47759,7 @@
     "name": "33 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000005458618",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47775,7 +47775,7 @@
     "name": "33 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000038022113",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47791,7 +47791,7 @@
     "name": "33 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000081465481",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47807,7 +47807,7 @@
     "name": "33 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000065229038",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47839,7 +47839,7 @@
     "name": "33 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000062196488",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47855,7 +47855,7 @@
     "name": "33 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000001514817",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47871,7 +47871,7 @@
     "name": "33 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000010091056",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47887,7 +47887,7 @@
     "name": "33 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000087439557",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47935,7 +47935,7 @@
     "name": "33 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000036279541",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -47951,7 +47951,7 @@
     "name": "33 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000090682483",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48127,7 +48127,7 @@
     "name": "34 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000072388281",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48175,7 +48175,7 @@
     "name": "34 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000045937423",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48191,7 +48191,7 @@
     "name": "34 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000054802839",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48207,7 +48207,7 @@
     "name": "34 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000102907047",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48271,7 +48271,7 @@
     "name": "34 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000019751297",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48287,7 +48287,7 @@
     "name": "34 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000032848469",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48303,7 +48303,7 @@
     "name": "34 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000063449256",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48351,7 +48351,7 @@
     "name": "34 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000072263469",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48367,7 +48367,7 @@
     "name": "34 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000029656641",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48383,7 +48383,7 @@
     "name": "34 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000104045815",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48415,7 +48415,7 @@
     "name": "34 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000009667265",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48447,7 +48447,7 @@
     "name": "34 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000045978790",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48479,7 +48479,7 @@
     "name": "34 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000088170934",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48495,7 +48495,7 @@
     "name": "34 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000040916417",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48511,7 +48511,7 @@
     "name": "34 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000090337063",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48527,7 +48527,7 @@
     "name": "34 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000062850477",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48543,7 +48543,7 @@
     "name": "34 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000080247136",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48559,7 +48559,7 @@
     "name": "34 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000078910070",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48575,7 +48575,7 @@
     "name": "34 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000048192162",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48623,7 +48623,7 @@
     "name": "34 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000103384898",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48639,7 +48639,7 @@
     "name": "34 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000096347940",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48655,7 +48655,7 @@
     "name": "34 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000037359656",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48671,7 +48671,7 @@
     "name": "34 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000101486242",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48687,7 +48687,7 @@
     "name": "34 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000015608382",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48703,7 +48703,7 @@
     "name": "34 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000062485347",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48879,7 +48879,7 @@
     "name": "35 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000027383427",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48911,7 +48911,7 @@
     "name": "35 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000054841862",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48975,7 +48975,7 @@
     "name": "35 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000086884156",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -48991,7 +48991,7 @@
     "name": "35 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000039828266",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49023,7 +49023,7 @@
     "name": "35 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000079681751",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49039,7 +49039,7 @@
     "name": "35 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000028042513",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49071,7 +49071,7 @@
     "name": "35 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000019736682",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49087,7 +49087,7 @@
     "name": "35 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000091531991",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49119,7 +49119,7 @@
     "name": "35 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000098698832",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49151,7 +49151,7 @@
     "name": "35 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000097830621",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49167,7 +49167,7 @@
     "name": "35 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000095583524",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49183,7 +49183,7 @@
     "name": "35 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000077510632",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49199,7 +49199,7 @@
     "name": "35 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000045530824",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49231,7 +49231,7 @@
     "name": "35 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000044259407",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49247,7 +49247,7 @@
     "name": "35 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000013059746",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49263,7 +49263,7 @@
     "name": "35 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000011807400",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49279,7 +49279,7 @@
     "name": "35 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000050279602",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49295,7 +49295,7 @@
     "name": "35 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000080004405",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49327,7 +49327,7 @@
     "name": "35 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000089188784",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49359,7 +49359,7 @@
     "name": "35 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000108293345",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49375,7 +49375,7 @@
     "name": "35 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000088604505",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49423,7 +49423,7 @@
     "name": "35A DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000039828266",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49439,7 +49439,7 @@
     "name": "35B DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000039977861",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49455,7 +49455,7 @@
     "name": "36 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000061354179",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49503,7 +49503,7 @@
     "name": "36 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000061199858",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49519,7 +49519,7 @@
     "name": "36 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000021544270",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49535,7 +49535,7 @@
     "name": "36 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000061311416",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49599,7 +49599,7 @@
     "name": "36 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000007912816",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49615,7 +49615,7 @@
     "name": "36 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000076600572",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49679,7 +49679,7 @@
     "name": "36 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000040165327",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49695,7 +49695,7 @@
     "name": "36 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000054606985",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49727,7 +49727,7 @@
     "name": "36 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000052170155",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49759,7 +49759,7 @@
     "name": "36 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000004625008",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49791,7 +49791,7 @@
     "name": "36 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000030866647",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49807,7 +49807,7 @@
     "name": "36 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000035753984",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49823,7 +49823,7 @@
     "name": "36 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000078748723",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49839,7 +49839,7 @@
     "name": "36 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000096887702",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49855,7 +49855,7 @@
     "name": "36 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000005097731",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49887,7 +49887,7 @@
     "name": "36 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000004882735",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49935,7 +49935,7 @@
     "name": "36 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000069830927",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49951,7 +49951,7 @@
     "name": "36 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000001458050",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49967,7 +49967,7 @@
     "name": "36 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000072475813",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49983,7 +49983,7 @@
     "name": "36 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000039433680",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -49999,7 +49999,7 @@
     "name": "36 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000063166156",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50015,7 +50015,7 @@
     "name": "36A WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000063017211",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50047,7 +50047,7 @@
     "name": "37 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000004162370",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50079,7 +50079,7 @@
     "name": "37 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000028147560",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50127,7 +50127,7 @@
     "name": "37 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000025833267",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50175,7 +50175,7 @@
     "name": "37 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000098352052",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50207,7 +50207,7 @@
     "name": "37 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000063979005",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50223,7 +50223,7 @@
     "name": "37 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000054720109",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50255,7 +50255,7 @@
     "name": "37 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000027237605",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50287,7 +50287,7 @@
     "name": "37 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000029147407",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50319,7 +50319,7 @@
     "name": "37 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000020639281",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50335,7 +50335,7 @@
     "name": "37 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000015010206",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50351,7 +50351,7 @@
     "name": "37 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000065474022",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50367,7 +50367,7 @@
     "name": "37 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000002291814",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50399,7 +50399,7 @@
     "name": "37 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000098053804",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50415,7 +50415,7 @@
     "name": "37 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000077886752",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50431,7 +50431,7 @@
     "name": "37 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000074599604",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50447,7 +50447,7 @@
     "name": "37 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000057927794",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50463,7 +50463,7 @@
     "name": "37 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000021395370",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50495,7 +50495,7 @@
     "name": "37 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000030406898",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50527,7 +50527,7 @@
     "name": "37 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000004535359",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50543,7 +50543,7 @@
     "name": "37 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000001635692",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50591,7 +50591,7 @@
     "name": "38 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000039642263",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50639,7 +50639,7 @@
     "name": "38 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000034775669",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50655,7 +50655,7 @@
     "name": "38 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000008050276",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50671,7 +50671,7 @@
     "name": "38 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000068395125",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50735,7 +50735,7 @@
     "name": "38 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000105317028",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50751,7 +50751,7 @@
     "name": "38 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000061005465",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50799,7 +50799,7 @@
     "name": "38 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000037446942",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50815,7 +50815,7 @@
     "name": "38 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000061118637",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50831,7 +50831,7 @@
     "name": "38 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000015885028",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50863,7 +50863,7 @@
     "name": "38 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000084301369",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50895,7 +50895,7 @@
     "name": "38 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000012191841",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50927,7 +50927,7 @@
     "name": "38 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000055748852",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50959,7 +50959,7 @@
     "name": "38 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000102210048",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50975,7 +50975,7 @@
     "name": "38 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000027298142",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -50991,7 +50991,7 @@
     "name": "38 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000109227527",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51007,7 +51007,7 @@
     "name": "38 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000074657011",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51039,7 +51039,7 @@
     "name": "38 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000086850155",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51055,7 +51055,7 @@
     "name": "38 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000085246358",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51071,7 +51071,7 @@
     "name": "38 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000050378803",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51087,7 +51087,7 @@
     "name": "39 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000039767035",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51119,7 +51119,7 @@
     "name": "39 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000057614304",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51151,7 +51151,7 @@
     "name": "39 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000098591662",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51199,7 +51199,7 @@
     "name": "39 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000046644371",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51231,7 +51231,7 @@
     "name": "39 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000069641962",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51247,7 +51247,7 @@
     "name": "39 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000068610766",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51263,7 +51263,7 @@
     "name": "39 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000101800289",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51295,7 +51295,7 @@
     "name": "39 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000032958802",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51327,7 +51327,7 @@
     "name": "39 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000072357602",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51343,7 +51343,7 @@
     "name": "39 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000080175894",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51359,7 +51359,7 @@
     "name": "39 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000064518666",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51391,7 +51391,7 @@
     "name": "39 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000094767981",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51407,7 +51407,7 @@
     "name": "39 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000097705978",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51423,7 +51423,7 @@
     "name": "39 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000095998909",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51439,7 +51439,7 @@
     "name": "39 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000016375905",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51455,7 +51455,7 @@
     "name": "39 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000099517316",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51471,7 +51471,7 @@
     "name": "39 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000076506396",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51487,7 +51487,7 @@
     "name": "39 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000063191118",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51503,7 +51503,7 @@
     "name": "3A BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000038625612",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51519,7 +51519,7 @@
     "name": "3A DARREN COURT GLENWOOD 2768",
     "locID": "LOC100081098669",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51535,7 +51535,7 @@
     "name": "3A KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000187050292",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51583,7 +51583,7 @@
     "name": "3B BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000041076591",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51615,7 +51615,7 @@
     "name": "4 ABDALE CRESCENT GLENWOOD 2768",
     "locID": "LOC000078420711",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51631,7 +51631,7 @@
     "name": "4 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000036713181",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51647,7 +51647,7 @@
     "name": "4 AGINCOURT PLACE GLENWOOD 2768",
     "locID": "LOC000018966212",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51663,7 +51663,7 @@
     "name": "4 ALI PLACE GLENWOOD 2768",
     "locID": "LOC000097801824",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51695,7 +51695,7 @@
     "name": "4 ALPINE WAY GLENWOOD 2768",
     "locID": "LOC000034677195",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51711,7 +51711,7 @@
     "name": "4 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000094669523",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51727,7 +51727,7 @@
     "name": "4 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000031761731",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51743,7 +51743,7 @@
     "name": "4 AMUET PLACE GLENWOOD 2768",
     "locID": "LOC000043277650",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51775,7 +51775,7 @@
     "name": "4 ANGEL COURT GLENWOOD 2768",
     "locID": "LOC000037395837",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51791,7 +51791,7 @@
     "name": "4 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000066718256",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51823,7 +51823,7 @@
     "name": "4 ARNIKA COURT GLENWOOD 2768",
     "locID": "LOC000121996627",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51855,7 +51855,7 @@
     "name": "4 ARROWSMITH STREET GLENWOOD 2768",
     "locID": "LOC000039757361",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51871,7 +51871,7 @@
     "name": "4 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000038045806",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51887,7 +51887,7 @@
     "name": "4 AVRIL COURT GLENWOOD 2768",
     "locID": "LOC000072518836",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51951,7 +51951,7 @@
     "name": "4 BAIL WAY GLENWOOD 2768",
     "locID": "LOC000057829273",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51967,7 +51967,7 @@
     "name": "4 BARBER PLACE GLENWOOD 2768",
     "locID": "LOC000050321001",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51983,7 +51983,7 @@
     "name": "4 BEAUMONT AVENUE GLENWOOD 2768",
     "locID": "LOC000087916659",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -51999,7 +51999,7 @@
     "name": "4 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000061359463",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52015,7 +52015,7 @@
     "name": "4 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000045909590",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52031,7 +52031,7 @@
     "name": "4 BETH WAY GLENWOOD 2768",
     "locID": "LOC000009690653",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52063,7 +52063,7 @@
     "name": "4 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000040374722",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52079,7 +52079,7 @@
     "name": "4 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000078495224",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52111,7 +52111,7 @@
     "name": "4 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000089553861",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52143,7 +52143,7 @@
     "name": "4 BRONTE AVENUE GLENWOOD 2768",
     "locID": "LOC000018150640",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52159,7 +52159,7 @@
     "name": "4 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000080214598",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52175,7 +52175,7 @@
     "name": "4 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000031942840",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52191,7 +52191,7 @@
     "name": "4 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000006437664",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52207,7 +52207,7 @@
     "name": "4 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000013116447",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52223,7 +52223,7 @@
     "name": "4 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000103846780",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52239,7 +52239,7 @@
     "name": "4 CAROONA WAY GLENWOOD 2768",
     "locID": "LOC000075523913",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52255,7 +52255,7 @@
     "name": "4 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000002997828",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52271,7 +52271,7 @@
     "name": "4 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000058550940",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52303,7 +52303,7 @@
     "name": "4 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000068632993",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52319,7 +52319,7 @@
     "name": "4 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000089998569",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52383,7 +52383,7 @@
     "name": "4 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000047573717",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52399,7 +52399,7 @@
     "name": "4 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000044493262",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52415,7 +52415,7 @@
     "name": "4 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000026484656",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52463,7 +52463,7 @@
     "name": "4 CURLEW STREET GLENWOOD 2768",
     "locID": "LOC000046210388",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52479,7 +52479,7 @@
     "name": "4 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000069263112",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52495,7 +52495,7 @@
     "name": "4 DARE STREET GLENWOOD 2768",
     "locID": "LOC000088070674",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52511,7 +52511,7 @@
     "name": "4 DARREN COURT GLENWOOD 2768",
     "locID": "LOC000075440302",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52543,7 +52543,7 @@
     "name": "4 DEAKIN AVENUE GLENWOOD 2768",
     "locID": "LOC000053256948",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52559,7 +52559,7 @@
     "name": "4 DENMAN COURT GLENWOOD 2768",
     "locID": "LOC000093600906",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52575,7 +52575,7 @@
     "name": "4 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000065167409",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52591,7 +52591,7 @@
     "name": "4 DIENELT CLOSE GLENWOOD 2768",
     "locID": "LOC000078523879",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52607,7 +52607,7 @@
     "name": "4 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000072234271",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52639,7 +52639,7 @@
     "name": "4 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000033278658",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52655,7 +52655,7 @@
     "name": "4 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000047173831",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52719,7 +52719,7 @@
     "name": "4 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000018851141",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52735,7 +52735,7 @@
     "name": "4 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000090403937",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52767,7 +52767,7 @@
     "name": "4 FINCH PLACE GLENWOOD 2768",
     "locID": "LOC000019843477",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52799,7 +52799,7 @@
     "name": "4 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000102409418",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52815,7 +52815,7 @@
     "name": "4 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000181333956",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52863,7 +52863,7 @@
     "name": "4 GLENLEA COURT GLENWOOD 2768",
     "locID": "LOC000023309038",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52895,7 +52895,7 @@
     "name": "4 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000007436381",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52911,7 +52911,7 @@
     "name": "4 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000018950850",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52927,7 +52927,7 @@
     "name": "4 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000063760592",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52975,7 +52975,7 @@
     "name": "4 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000052406753",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -52991,7 +52991,7 @@
     "name": "4 HAMBRO AVENUE GLENWOOD 2768",
     "locID": "LOC000014680103",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53007,7 +53007,7 @@
     "name": "4 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000110155964",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53023,7 +53023,7 @@
     "name": "4 HERITAGE PLACE GLENWOOD 2768",
     "locID": "LOC000068287142",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53039,7 +53039,7 @@
     "name": "4 HEVRELL COURT GLENWOOD 2768",
     "locID": "LOC000064757137",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53055,7 +53055,7 @@
     "name": "4 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000025484290",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53071,7 +53071,7 @@
     "name": "4 HOYA WAY GLENWOOD 2768",
     "locID": "LOC000121996636",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53087,7 +53087,7 @@
     "name": "4 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000007413337",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53103,7 +53103,7 @@
     "name": "4 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000102314190",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53135,7 +53135,7 @@
     "name": "4 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121996643",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53167,7 +53167,7 @@
     "name": "4 JOYCE STREET GLENWOOD 2768",
     "locID": "LOC000080772399",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53183,7 +53183,7 @@
     "name": "4 KANDOS STREET GLENWOOD 2768",
     "locID": "LOC000100244545",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53231,7 +53231,7 @@
     "name": "4 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000009206061",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53247,7 +53247,7 @@
     "name": "4 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000057659231",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53279,7 +53279,7 @@
     "name": "4 KOOKABURRA GROVE GLENWOOD 2768",
     "locID": "LOC000100083720",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53311,7 +53311,7 @@
     "name": "4 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000040495405",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53327,7 +53327,7 @@
     "name": "4 KYALITE STREET GLENWOOD 2768",
     "locID": "LOC000072604872",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53343,7 +53343,7 @@
     "name": "4 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000067440200",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53359,7 +53359,7 @@
     "name": "4 LEMON GROVE GLENWOOD 2768",
     "locID": "LOC000095965862",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53407,7 +53407,7 @@
     "name": "4 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000008121294",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53423,7 +53423,7 @@
     "name": "4 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000065396016",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53439,7 +53439,7 @@
     "name": "4 MAGPIE COURT GLENWOOD 2768",
     "locID": "LOC000121996658",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53471,7 +53471,7 @@
     "name": "4 MALEY GROVE GLENWOOD 2768",
     "locID": "LOC000038219055",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53487,7 +53487,7 @@
     "name": "4 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000083792423",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53503,7 +53503,7 @@
     "name": "4 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000033156044",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53519,7 +53519,7 @@
     "name": "4 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000098957255",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53535,7 +53535,7 @@
     "name": "4 MARS WAY GLENWOOD 2768",
     "locID": "LOC000025413836",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53567,7 +53567,7 @@
     "name": "4 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000025109179",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53583,7 +53583,7 @@
     "name": "4 MCMAHON GROVE GLENWOOD 2768",
     "locID": "LOC000105212971",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53615,7 +53615,7 @@
     "name": "4 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000037083590",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53631,7 +53631,7 @@
     "name": "4 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000102276033",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53647,7 +53647,7 @@
     "name": "4 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000108447125",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53663,7 +53663,7 @@
     "name": "4 MINKI WAY GLENWOOD 2768",
     "locID": "LOC000007235978",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53679,7 +53679,7 @@
     "name": "4 MINUET COURT GLENWOOD 2768",
     "locID": "LOC000060975187",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53711,7 +53711,7 @@
     "name": "4 MOULAMEIN TERRACE GLENWOOD 2768",
     "locID": "LOC000110016974",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53727,7 +53727,7 @@
     "name": "4 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000052870849",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53743,7 +53743,7 @@
     "name": "4 NESH PLACE GLENWOOD 2768",
     "locID": "LOC000121996662",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53759,7 +53759,7 @@
     "name": "4 NEWNES CLOSE GLENWOOD 2768",
     "locID": "LOC000054787567",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53775,7 +53775,7 @@
     "name": "4 NIXON STREET GLENWOOD 2768",
     "locID": "LOC000006361357",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53791,7 +53791,7 @@
     "name": "4 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000088227239",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53807,7 +53807,7 @@
     "name": "4 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000088171775",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53823,7 +53823,7 @@
     "name": "4 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000012326636",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53839,7 +53839,7 @@
     "name": "4 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000072060975",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53855,7 +53855,7 @@
     "name": "4 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000064358871",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53871,7 +53871,7 @@
     "name": "4 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000007234347",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53903,7 +53903,7 @@
     "name": "4 PERIDOT PLACE GLENWOOD 2768",
     "locID": "LOC000048632283",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53919,7 +53919,7 @@
     "name": "4 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000094182398",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53967,7 +53967,7 @@
     "name": "4 PINNACLE WAY GLENWOOD 2768",
     "locID": "LOC000022257234",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53983,7 +53983,7 @@
     "name": "4 PLUM GARDENS GLENWOOD 2768",
     "locID": "LOC000057684639",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -53999,7 +53999,7 @@
     "name": "4 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000007202495",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54015,7 +54015,7 @@
     "name": "4 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000040025840",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54047,7 +54047,7 @@
     "name": "4 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000080227836",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54063,7 +54063,7 @@
     "name": "4 RAYWOOD COURT GLENWOOD 2768",
     "locID": "LOC000058722198",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54079,7 +54079,7 @@
     "name": "4 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000099149126",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54111,7 +54111,7 @@
     "name": "4 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000114009396",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54143,7 +54143,7 @@
     "name": "4 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000110198520",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54159,7 +54159,7 @@
     "name": "4 RYDER STREET GLENWOOD 2768",
     "locID": "LOC000046336378",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54223,7 +54223,7 @@
     "name": "4 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000021431312",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54239,7 +54239,7 @@
     "name": "4 SENTINEL STREET GLENWOOD 2768",
     "locID": "LOC000019657262",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54255,7 +54255,7 @@
     "name": "4 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000057187454",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54271,7 +54271,7 @@
     "name": "4 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000052762909",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54303,7 +54303,7 @@
     "name": "4 SILVERTON STREET GLENWOOD 2768",
     "locID": "LOC000077377721",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54335,7 +54335,7 @@
     "name": "4 SOLAR PLACE GLENWOOD 2768",
     "locID": "LOC000096412470",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54351,7 +54351,7 @@
     "name": "4 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000093420111",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54383,7 +54383,7 @@
     "name": "4 STRAWBERRY WAY GLENWOOD 2768",
     "locID": "LOC000021427614",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54399,7 +54399,7 @@
     "name": "4 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000004216148",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54415,7 +54415,7 @@
     "name": "4 SWANSEA COURT GLENWOOD 2768",
     "locID": "LOC000114989883",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54447,7 +54447,7 @@
     "name": "4 TANN-DARBY COURT GLENWOOD 2768",
     "locID": "LOC000064434511",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54463,7 +54463,7 @@
     "name": "4 TAWNY CLOSE GLENWOOD 2768",
     "locID": "LOC000092251052",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54479,7 +54479,7 @@
     "name": "4 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000027103468",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54495,7 +54495,7 @@
     "name": "4 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000009730913",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54527,7 +54527,7 @@
     "name": "4 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000105221359",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54543,7 +54543,7 @@
     "name": "4 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000114047451",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54559,7 +54559,7 @@
     "name": "4 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000015536115",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54591,7 +54591,7 @@
     "name": "4 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000028821534",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54607,7 +54607,7 @@
     "name": "4 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000040471075",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54623,7 +54623,7 @@
     "name": "4 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000075781396",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54639,7 +54639,7 @@
     "name": "4 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000086505786",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54655,7 +54655,7 @@
     "name": "4 WILLOWLEAF CLOSE GLENWOOD 2768",
     "locID": "LOC000048085304",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54671,7 +54671,7 @@
     "name": "4 YANCO GLEN GLENWOOD 2768",
     "locID": "LOC000002249628",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54703,7 +54703,7 @@
     "name": "4 ZENITH COURT GLENWOOD 2768",
     "locID": "LOC000110032219",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54735,7 +54735,7 @@
     "name": "40 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000087513003",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54783,7 +54783,7 @@
     "name": "40 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000072237712",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54799,7 +54799,7 @@
     "name": "40 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000066582799",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54863,7 +54863,7 @@
     "name": "40 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000038421772",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54879,7 +54879,7 @@
     "name": "40 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000099795419",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54927,7 +54927,7 @@
     "name": "40 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000069564016",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54943,7 +54943,7 @@
     "name": "40 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000107470871",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -54975,7 +54975,7 @@
     "name": "40 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000042270232",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55007,7 +55007,7 @@
     "name": "40 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000037197414",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55039,7 +55039,7 @@
     "name": "40 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000101280968",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55071,7 +55071,7 @@
     "name": "40 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000066339037",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55087,7 +55087,7 @@
     "name": "40 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000030107457",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55103,7 +55103,7 @@
     "name": "40 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000044165429",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55135,7 +55135,7 @@
     "name": "40 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000010552526",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55151,7 +55151,7 @@
     "name": "40 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000016321114",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55167,7 +55167,7 @@
     "name": "40 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000084079274",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55183,7 +55183,7 @@
     "name": "40 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000037207665",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55199,7 +55199,7 @@
     "name": "41 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000014721844",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55231,7 +55231,7 @@
     "name": "41 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000098528781",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55263,7 +55263,7 @@
     "name": "41 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000071340474",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55295,7 +55295,7 @@
     "name": "41 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000016301215",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55311,7 +55311,7 @@
     "name": "41 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000101906603",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55343,7 +55343,7 @@
     "name": "41 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000057504241",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55359,7 +55359,7 @@
     "name": "41 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000088102786",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55391,7 +55391,7 @@
     "name": "41 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000086670506",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55423,7 +55423,7 @@
     "name": "41 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000055948227",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55439,7 +55439,7 @@
     "name": "41 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000022286671",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55455,7 +55455,7 @@
     "name": "41 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000089121578",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55471,7 +55471,7 @@
     "name": "41 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000027041173",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55503,7 +55503,7 @@
     "name": "41 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000075725596",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55519,7 +55519,7 @@
     "name": "41 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000008957037",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55535,7 +55535,7 @@
     "name": "41 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000045941388",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55551,7 +55551,7 @@
     "name": "41 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000044337885",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55567,7 +55567,7 @@
     "name": "41 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000090807125",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55583,7 +55583,7 @@
     "name": "41 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000027364065",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55599,7 +55599,7 @@
     "name": "41 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000089263232",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55695,7 +55695,7 @@
     "name": "42 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000080888826",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55711,7 +55711,7 @@
     "name": "42 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000018395144",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55759,7 +55759,7 @@
     "name": "42 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000106957573",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55791,7 +55791,7 @@
     "name": "42 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000076987209",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55807,7 +55807,7 @@
     "name": "42 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000006429079",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55839,7 +55839,7 @@
     "name": "42 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000042039898",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55855,7 +55855,7 @@
     "name": "42 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000023706184",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55887,7 +55887,7 @@
     "name": "42 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000026268103",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55919,7 +55919,7 @@
     "name": "42 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000107362529",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55935,7 +55935,7 @@
     "name": "42 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000059118616",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55967,7 +55967,7 @@
     "name": "42 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000054835969",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55983,7 +55983,7 @@
     "name": "42 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000042814387",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -55999,7 +55999,7 @@
     "name": "42 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000095863877",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56015,7 +56015,7 @@
     "name": "42 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000018428595",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56047,7 +56047,7 @@
     "name": "43 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000065091064",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56079,7 +56079,7 @@
     "name": "43 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000064507613",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56111,7 +56111,7 @@
     "name": "43 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000020573486",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56143,7 +56143,7 @@
     "name": "43 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000042769275",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56159,7 +56159,7 @@
     "name": "43 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000090164082",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56191,7 +56191,7 @@
     "name": "43 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000083825513",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56207,7 +56207,7 @@
     "name": "43 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000008062254",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56239,7 +56239,7 @@
     "name": "43 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000011281326",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56255,7 +56255,7 @@
     "name": "43 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000044190807",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56271,7 +56271,7 @@
     "name": "43 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000092468200",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56287,7 +56287,7 @@
     "name": "43 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000087351833",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56319,7 +56319,7 @@
     "name": "43 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000086479018",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56335,7 +56335,7 @@
     "name": "43 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000058317646",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56367,7 +56367,7 @@
     "name": "43 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000047720974",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56383,7 +56383,7 @@
     "name": "43 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000001569300",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56399,7 +56399,7 @@
     "name": "43 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000086206973",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56415,7 +56415,7 @@
     "name": "43 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000060908129",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56479,7 +56479,7 @@
     "name": "44 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000035401325",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56527,7 +56527,7 @@
     "name": "44 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000011350745",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56559,7 +56559,7 @@
     "name": "44 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000107882240",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56575,7 +56575,7 @@
     "name": "44 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000053353410",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56607,7 +56607,7 @@
     "name": "44 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000101349917",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56623,7 +56623,7 @@
     "name": "44 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000033866788",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56639,7 +56639,7 @@
     "name": "44 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000021508135",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56655,7 +56655,7 @@
     "name": "44 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000064363196",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56671,7 +56671,7 @@
     "name": "44 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000035521941",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56687,7 +56687,7 @@
     "name": "44 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000082464340",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56719,7 +56719,7 @@
     "name": "44 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000052697727",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56735,7 +56735,7 @@
     "name": "44 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000029582824",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56767,7 +56767,7 @@
     "name": "44A VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000164967694",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56783,7 +56783,7 @@
     "name": "45 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000063131025",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56815,7 +56815,7 @@
     "name": "45 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000043901854",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56847,7 +56847,7 @@
     "name": "45 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000032515064",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56879,7 +56879,7 @@
     "name": "45 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000105276813",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56911,7 +56911,7 @@
     "name": "45 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000047871042",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56927,7 +56927,7 @@
     "name": "45 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000032941035",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56943,7 +56943,7 @@
     "name": "45 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000008961449",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -56991,7 +56991,7 @@
     "name": "45 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000101285961",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57023,7 +57023,7 @@
     "name": "45 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000012334790",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57039,7 +57039,7 @@
     "name": "45 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000061268706",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57071,7 +57071,7 @@
     "name": "45 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000106286358",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57087,7 +57087,7 @@
     "name": "45 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000097991929",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57103,7 +57103,7 @@
     "name": "45 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000027469767",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57119,7 +57119,7 @@
     "name": "45 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000022203611",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57135,7 +57135,7 @@
     "name": "45 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000048226635",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57151,7 +57151,7 @@
     "name": "45 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000025390051",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57183,7 +57183,7 @@
     "name": "46 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000025542814",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57199,7 +57199,7 @@
     "name": "46 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000110138742",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57247,7 +57247,7 @@
     "name": "46 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000087541268",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57279,7 +57279,7 @@
     "name": "46 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000088439748",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57295,7 +57295,7 @@
     "name": "46 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000072151507",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57327,7 +57327,7 @@
     "name": "46 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000057696424",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57359,7 +57359,7 @@
     "name": "46 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000085219186",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57375,7 +57375,7 @@
     "name": "46 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000022276428",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57391,7 +57391,7 @@
     "name": "46 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000052694604",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57423,7 +57423,7 @@
     "name": "46 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000001525618",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57439,7 +57439,7 @@
     "name": "46 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000087772251",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57455,7 +57455,7 @@
     "name": "46A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000052656538",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57471,7 +57471,7 @@
     "name": "47 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000073721395",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57503,7 +57503,7 @@
     "name": "47 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000013132801",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57519,7 +57519,7 @@
     "name": "47 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000082876933",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57551,7 +57551,7 @@
     "name": "47 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000008130713",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57583,7 +57583,7 @@
     "name": "47 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000082842482",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57599,7 +57599,7 @@
     "name": "47 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000026455069",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57615,7 +57615,7 @@
     "name": "47 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000095394915",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57647,7 +57647,7 @@
     "name": "47 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000059204711",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57663,7 +57663,7 @@
     "name": "47 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000104949278",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57679,7 +57679,7 @@
     "name": "47 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000018854962",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57695,7 +57695,7 @@
     "name": "47 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000001389263",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57711,7 +57711,7 @@
     "name": "47 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000010994175",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57727,7 +57727,7 @@
     "name": "47 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000097956025",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57743,7 +57743,7 @@
     "name": "47 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000102406204",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57759,7 +57759,7 @@
     "name": "47 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000078377635",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57775,7 +57775,7 @@
     "name": "47 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000057807257",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57807,7 +57807,7 @@
     "name": "47 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000108280633",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57839,7 +57839,7 @@
     "name": "48 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000075303435",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57855,7 +57855,7 @@
     "name": "48 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000065032407",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57871,7 +57871,7 @@
     "name": "48 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000094890590",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57903,7 +57903,7 @@
     "name": "48 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000018836520",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57919,7 +57919,7 @@
     "name": "48 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000070065254",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57951,7 +57951,7 @@
     "name": "48 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000094587281",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -57999,7 +57999,7 @@
     "name": "48 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000013301348",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58015,7 +58015,7 @@
     "name": "48 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000027227321",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58047,7 +58047,7 @@
     "name": "48 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000049411316",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58127,7 +58127,7 @@
     "name": "49 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000059421939",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58159,7 +58159,7 @@
     "name": "49 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000078236823",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58191,7 +58191,7 @@
     "name": "49 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000065353858",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58207,7 +58207,7 @@
     "name": "49 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000095898879",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58239,7 +58239,7 @@
     "name": "49 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000102991931",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58255,7 +58255,7 @@
     "name": "49 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000096188591",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58271,7 +58271,7 @@
     "name": "49 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000097313025",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58287,7 +58287,7 @@
     "name": "49 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000087466588",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58303,7 +58303,7 @@
     "name": "49 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000081472521",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58319,7 +58319,7 @@
     "name": "49 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000102300587",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58335,7 +58335,7 @@
     "name": "49 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000027140415",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58351,7 +58351,7 @@
     "name": "49 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000071496451",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58415,7 +58415,7 @@
     "name": "4A MONTVIEW WAY GLENWOOD 2768",
     "locID": "LOC000189708958",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58431,7 +58431,7 @@
     "name": "4A NESH PLACE GLENWOOD 2768",
     "locID": "LOC000153956359",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58447,7 +58447,7 @@
     "name": "4A-4B NESH PLACE GLENWOOD 2768",
     "locID": "LOC000121996662",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58463,7 +58463,7 @@
     "name": "4B NESH PLACE GLENWOOD 2768",
     "locID": "LOC000121996662",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58479,7 +58479,7 @@
     "name": "5 ABDALE CRESCENT GLENWOOD 2768",
     "locID": "LOC000030418802",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58495,7 +58495,7 @@
     "name": "5 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000021424221",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58511,7 +58511,7 @@
     "name": "5 AGINCOURT PLACE GLENWOOD 2768",
     "locID": "LOC000017577345",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58527,7 +58527,7 @@
     "name": "5 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000091497990",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58543,7 +58543,7 @@
     "name": "5 ALMONA STREET GLENWOOD 2768",
     "locID": "LOC000095915055",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58559,7 +58559,7 @@
     "name": "5 ALPINE WAY GLENWOOD 2768",
     "locID": "LOC000048340783",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58575,7 +58575,7 @@
     "name": "5 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000041439287",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58591,7 +58591,7 @@
     "name": "5 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000008997798",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58607,7 +58607,7 @@
     "name": "5 AMUET PLACE GLENWOOD 2768",
     "locID": "LOC000009808756",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58639,7 +58639,7 @@
     "name": "5 ANGEL COURT GLENWOOD 2768",
     "locID": "LOC000042616258",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58655,7 +58655,7 @@
     "name": "5 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000016365345",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58671,7 +58671,7 @@
     "name": "5 ANITA STREET GLENWOOD 2768",
     "locID": "LOC000030495827",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58703,7 +58703,7 @@
     "name": "5 ARNIKA COURT GLENWOOD 2768",
     "locID": "LOC000121996712",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58751,7 +58751,7 @@
     "name": "5 AVRIL COURT GLENWOOD 2768",
     "locID": "LOC000023072820",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58799,7 +58799,7 @@
     "name": "5 BAIL WAY GLENWOOD 2768",
     "locID": "LOC000065235869",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58815,7 +58815,7 @@
     "name": "5 BEAUMONT AVENUE GLENWOOD 2768",
     "locID": "LOC000023742884",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58831,7 +58831,7 @@
     "name": "5 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000004696074",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58847,7 +58847,7 @@
     "name": "5 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000043714120",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58879,7 +58879,7 @@
     "name": "5 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000061091862",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58895,7 +58895,7 @@
     "name": "5 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000052721859",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58927,7 +58927,7 @@
     "name": "5 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000067706742",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58943,7 +58943,7 @@
     "name": "5 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916147",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58959,7 +58959,7 @@
     "name": "5 BRONTE AVENUE GLENWOOD 2768",
     "locID": "LOC000055921550",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58975,7 +58975,7 @@
     "name": "5 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000016467894",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -58991,7 +58991,7 @@
     "name": "5 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000063421812",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59007,7 +59007,7 @@
     "name": "5 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000053123032",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59023,7 +59023,7 @@
     "name": "5 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000024191217",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59039,7 +59039,7 @@
     "name": "5 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000035923705",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59055,7 +59055,7 @@
     "name": "5 CAROONA WAY GLENWOOD 2768",
     "locID": "LOC000037120206",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59071,7 +59071,7 @@
     "name": "5 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000079634673",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59087,7 +59087,7 @@
     "name": "5 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000066546106",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59135,7 +59135,7 @@
     "name": "5 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000065438347",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59199,7 +59199,7 @@
     "name": "5 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000007367852",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59215,7 +59215,7 @@
     "name": "5 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000095316719",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59231,7 +59231,7 @@
     "name": "5 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000065148199",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59279,7 +59279,7 @@
     "name": "5 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000052823687",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59295,7 +59295,7 @@
     "name": "5 DEAKIN AVENUE GLENWOOD 2768",
     "locID": "LOC000080350126",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59311,7 +59311,7 @@
     "name": "5 DENMAN COURT GLENWOOD 2768",
     "locID": "LOC000067632179",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59327,7 +59327,7 @@
     "name": "5 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000090576137",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59343,7 +59343,7 @@
     "name": "5 DIENELT CLOSE GLENWOOD 2768",
     "locID": "LOC000077795882",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59359,7 +59359,7 @@
     "name": "5 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000021584751",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59375,7 +59375,7 @@
     "name": "5 EAGLE WAY GLENWOOD 2768",
     "locID": "LOC000041199190",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59423,7 +59423,7 @@
     "name": "5 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000072619319",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59455,7 +59455,7 @@
     "name": "5 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000021453458",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59503,7 +59503,7 @@
     "name": "5 EUREKA GROVE GLENWOOD 2768",
     "locID": "LOC000024162448",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59535,7 +59535,7 @@
     "name": "5 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000087513137",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59551,7 +59551,7 @@
     "name": "5 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000077754206",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59583,7 +59583,7 @@
     "name": "5 FIG TERRACE GLENWOOD 2768",
     "locID": "LOC000098675987",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59599,7 +59599,7 @@
     "name": "5 FINCH PLACE GLENWOOD 2768",
     "locID": "LOC000011410643",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59631,7 +59631,7 @@
     "name": "5 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000033235359",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59647,7 +59647,7 @@
     "name": "5 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000086294212",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59663,7 +59663,7 @@
     "name": "5 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000055630141",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59679,7 +59679,7 @@
     "name": "5 GARNET GROVE GLENWOOD 2768",
     "locID": "LOC000013821508",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59727,7 +59727,7 @@
     "name": "5 GLENLEA COURT GLENWOOD 2768",
     "locID": "LOC000021484313",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59759,7 +59759,7 @@
     "name": "5 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000101126487",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59775,7 +59775,7 @@
     "name": "5 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000029116977",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59791,7 +59791,7 @@
     "name": "5 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000068105277",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59839,7 +59839,7 @@
     "name": "5 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000051426907",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59855,7 +59855,7 @@
     "name": "5 HAMBRO AVENUE GLENWOOD 2768",
     "locID": "LOC000050231964",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59871,7 +59871,7 @@
     "name": "5 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000069421679",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59887,7 +59887,7 @@
     "name": "5 HERITAGE PLACE GLENWOOD 2768",
     "locID": "LOC000069619894",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59903,7 +59903,7 @@
     "name": "5 HEVRELL COURT GLENWOOD 2768",
     "locID": "LOC000051779481",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59919,7 +59919,7 @@
     "name": "5 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000097480082",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59951,7 +59951,7 @@
     "name": "5 HONEYEATER TERRACE GLENWOOD 2768",
     "locID": "LOC000082322263",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59967,7 +59967,7 @@
     "name": "5 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000024130829",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -59999,7 +59999,7 @@
     "name": "5 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000121996720",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60031,7 +60031,7 @@
     "name": "5 JOYCE STREET GLENWOOD 2768",
     "locID": "LOC000029763759",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60047,7 +60047,7 @@
     "name": "5 KANDOS STREET GLENWOOD 2768",
     "locID": "LOC000003905591",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60063,7 +60063,7 @@
     "name": "5 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000092612935",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60095,7 +60095,7 @@
     "name": "5 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000069880854",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60111,7 +60111,7 @@
     "name": "5 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000084187054",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60143,7 +60143,7 @@
     "name": "5 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000086117714",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60159,7 +60159,7 @@
     "name": "5 KOOKABURRA GROVE GLENWOOD 2768",
     "locID": "LOC000104418312",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60191,7 +60191,7 @@
     "name": "5 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000081315119",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60207,7 +60207,7 @@
     "name": "5 KYALITE STREET GLENWOOD 2768",
     "locID": "LOC000028835842",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60223,7 +60223,7 @@
     "name": "5 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000005093119",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60239,7 +60239,7 @@
     "name": "5 LEMON GROVE GLENWOOD 2768",
     "locID": "LOC000039157628",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60271,7 +60271,7 @@
     "name": "5 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000069058456",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60287,7 +60287,7 @@
     "name": "5 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000066363293",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60303,7 +60303,7 @@
     "name": "5 MAGPIE COURT GLENWOOD 2768",
     "locID": "LOC000121996731",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60335,7 +60335,7 @@
     "name": "5 MALEY GROVE GLENWOOD 2768",
     "locID": "LOC000096257361",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60351,7 +60351,7 @@
     "name": "5 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000153932630",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60367,7 +60367,7 @@
     "name": "5 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000055072907",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60383,7 +60383,7 @@
     "name": "5 MARS WAY GLENWOOD 2768",
     "locID": "LOC000108978971",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60399,7 +60399,7 @@
     "name": "5 MATARA WAY GLENWOOD 2768",
     "locID": "LOC000057165284",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60415,7 +60415,7 @@
     "name": "5 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000028695499",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60447,7 +60447,7 @@
     "name": "5 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000061027883",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60463,7 +60463,7 @@
     "name": "5 MIAMI STREET GLENWOOD 2768",
     "locID": "LOC000102138598",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60479,7 +60479,7 @@
     "name": "5 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000088507583",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60495,7 +60495,7 @@
     "name": "5 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000029632664",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60511,7 +60511,7 @@
     "name": "5 MINUET COURT GLENWOOD 2768",
     "locID": "LOC000099588770",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60559,7 +60559,7 @@
     "name": "5 MUSCAT GROVE GLENWOOD 2768",
     "locID": "LOC000107473498",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60575,7 +60575,7 @@
     "name": "5 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000098220182",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60591,7 +60591,7 @@
     "name": "5 NESH PLACE GLENWOOD 2768",
     "locID": "LOC000122000135",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60607,7 +60607,7 @@
     "name": "5 NEWNES CLOSE GLENWOOD 2768",
     "locID": "LOC000051484535",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60623,7 +60623,7 @@
     "name": "5 NIXON STREET GLENWOOD 2768",
     "locID": "LOC000042097731",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60639,7 +60639,7 @@
     "name": "5 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000063776134",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60655,7 +60655,7 @@
     "name": "5 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000035848144",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60671,7 +60671,7 @@
     "name": "5 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000002379154",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60687,7 +60687,7 @@
     "name": "5 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000063366838",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60703,7 +60703,7 @@
     "name": "5 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000060235516",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60719,7 +60719,7 @@
     "name": "5 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000100867922",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60735,7 +60735,7 @@
     "name": "5 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000095746533",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60751,7 +60751,7 @@
     "name": "5 PEACH GARDENS GLENWOOD 2768",
     "locID": "LOC000079934055",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60799,7 +60799,7 @@
     "name": "5 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000015016986",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60847,7 +60847,7 @@
     "name": "5 PINNACLE WAY GLENWOOD 2768",
     "locID": "LOC000063427396",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60863,7 +60863,7 @@
     "name": "5 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000074433298",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60879,7 +60879,7 @@
     "name": "5 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000089579540",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60895,7 +60895,7 @@
     "name": "5 POPPY WAY GLENWOOD 2768",
     "locID": "LOC000122000142",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60911,7 +60911,7 @@
     "name": "5 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000096043590",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60943,7 +60943,7 @@
     "name": "5 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000049903497",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60959,7 +60959,7 @@
     "name": "5 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000114782945",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -60991,7 +60991,7 @@
     "name": "5 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000013025824",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61005,7 +61005,7 @@
    },
    "properties": {
     "name": "5 SARDINIA AVENUE GLENWOOD 2768",
-    "locID": "LOC000041047072",
+    "locID": "LOC000017993662",
     "tech": "FTTN",
     "upgrade": "FTTP_NA"
    }
@@ -61039,7 +61039,7 @@
     "name": "5 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000065182923",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61055,7 +61055,7 @@
     "name": "5 SENTINEL STREET GLENWOOD 2768",
     "locID": "LOC000002353277",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61071,7 +61071,7 @@
     "name": "5 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000037463262",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61087,7 +61087,7 @@
     "name": "5 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000041883066",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61103,7 +61103,7 @@
     "name": "5 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000046990626",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61151,7 +61151,7 @@
     "name": "5 SOLAR PLACE GLENWOOD 2768",
     "locID": "LOC000052930597",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61167,7 +61167,7 @@
     "name": "5 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000057719770",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61183,7 +61183,7 @@
     "name": "5 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000015433147",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61199,7 +61199,7 @@
     "name": "5 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000018855406",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61215,7 +61215,7 @@
     "name": "5 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000044500807",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61247,7 +61247,7 @@
     "name": "5 STRAWBERRY WAY GLENWOOD 2768",
     "locID": "LOC000037930122",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61263,7 +61263,7 @@
     "name": "5 SULTANA GROVE GLENWOOD 2768",
     "locID": "LOC000103488025",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61279,7 +61279,7 @@
     "name": "5 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000078062949",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61295,7 +61295,7 @@
     "name": "5 SWANSEA COURT GLENWOOD 2768",
     "locID": "LOC000114769818",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61327,7 +61327,7 @@
     "name": "5 TANN-DARBY COURT GLENWOOD 2768",
     "locID": "LOC000091980424",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61343,7 +61343,7 @@
     "name": "5 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000055041324",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61359,7 +61359,7 @@
     "name": "5 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000088668789",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61375,7 +61375,7 @@
     "name": "5 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000032222891",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61391,7 +61391,7 @@
     "name": "5 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000113222013",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61407,7 +61407,7 @@
     "name": "5 WALTHAM WAY GLENWOOD 2768",
     "locID": "LOC000051437910",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61423,7 +61423,7 @@
     "name": "5 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000069114278",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61439,7 +61439,7 @@
     "name": "5 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000052716498",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61471,7 +61471,7 @@
     "name": "5 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000028336895",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61487,7 +61487,7 @@
     "name": "5 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000053171826",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61503,7 +61503,7 @@
     "name": "5 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000074476573",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61519,7 +61519,7 @@
     "name": "5 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000105523362",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61535,7 +61535,7 @@
     "name": "5 WILLOWLEAF CLOSE GLENWOOD 2768",
     "locID": "LOC000024831107",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61551,7 +61551,7 @@
     "name": "5 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000041565476",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61567,7 +61567,7 @@
     "name": "5 YANCO GLEN GLENWOOD 2768",
     "locID": "LOC000014158090",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61599,7 +61599,7 @@
     "name": "5 ZENITH COURT GLENWOOD 2768",
     "locID": "LOC000080037827",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61615,7 +61615,7 @@
     "name": "50 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000077802438",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61631,7 +61631,7 @@
     "name": "50 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000012350438",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61679,7 +61679,7 @@
     "name": "50 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000055461637",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61711,7 +61711,7 @@
     "name": "50 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000030040669",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61727,7 +61727,7 @@
     "name": "50 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000055386227",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61759,7 +61759,7 @@
     "name": "50 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000030430213",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61791,7 +61791,7 @@
     "name": "50 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000070904019",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61807,7 +61807,7 @@
     "name": "50 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000044268575",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61823,7 +61823,7 @@
     "name": "50 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000065516063",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61855,7 +61855,7 @@
     "name": "50 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000024785913",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61919,7 +61919,7 @@
     "name": "51 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000077199472",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61951,7 +61951,7 @@
     "name": "51 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000082851519",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61983,7 +61983,7 @@
     "name": "51 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000063084778",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -61999,7 +61999,7 @@
     "name": "51 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000009623171",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62031,7 +62031,7 @@
     "name": "51 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000082519068",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62047,7 +62047,7 @@
     "name": "51 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000022145998",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62063,7 +62063,7 @@
     "name": "51 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000083135905",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62079,7 +62079,7 @@
     "name": "51 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000032865905",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62095,7 +62095,7 @@
     "name": "51 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000002998277",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62111,7 +62111,7 @@
     "name": "51 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000094600633",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62127,7 +62127,7 @@
     "name": "51 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000077010279",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62143,7 +62143,7 @@
     "name": "51 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000100131545",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62159,7 +62159,7 @@
     "name": "52 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000003297719",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62191,7 +62191,7 @@
     "name": "52 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000076487864",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62223,7 +62223,7 @@
     "name": "52 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000088057217",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62239,7 +62239,7 @@
     "name": "52 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000104920827",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62271,7 +62271,7 @@
     "name": "52 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000015621701",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62303,7 +62303,7 @@
     "name": "52 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000028954405",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62319,7 +62319,7 @@
     "name": "52 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000108022726",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62335,7 +62335,7 @@
     "name": "52 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000043624863",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62367,7 +62367,7 @@
     "name": "52 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000099610137",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62399,7 +62399,7 @@
     "name": "53 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000055622980",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62431,7 +62431,7 @@
     "name": "53 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000084231033",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62463,7 +62463,7 @@
     "name": "53 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000004618663",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62479,7 +62479,7 @@
     "name": "53 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000080378282",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62511,7 +62511,7 @@
     "name": "53 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000089744223",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62527,7 +62527,7 @@
     "name": "53 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000088096400",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62543,7 +62543,7 @@
     "name": "53 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000032282576",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62559,7 +62559,7 @@
     "name": "53 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000061166264",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62575,7 +62575,7 @@
     "name": "53 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000051413382",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62591,7 +62591,7 @@
     "name": "53 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000079699290",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62607,7 +62607,7 @@
     "name": "53 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000017152146",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62623,7 +62623,7 @@
     "name": "53 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000077030912",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62639,7 +62639,7 @@
     "name": "53 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000056105804",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62655,7 +62655,7 @@
     "name": "54 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000078556845",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62687,7 +62687,7 @@
     "name": "54 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000060939400",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62719,7 +62719,7 @@
     "name": "54 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000073494585",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62735,7 +62735,7 @@
     "name": "54 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000090682243",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62767,7 +62767,7 @@
     "name": "54 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000007229295",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62799,7 +62799,7 @@
     "name": "54 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000006278284",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62815,7 +62815,7 @@
     "name": "54 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000035768846",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62847,7 +62847,7 @@
     "name": "54 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000104354224",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62879,7 +62879,7 @@
     "name": "55 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000017624831",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62927,7 +62927,7 @@
     "name": "55 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000058174354",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62959,7 +62959,7 @@
     "name": "55 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000013164997",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62975,7 +62975,7 @@
     "name": "55 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000037101489",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -62991,7 +62991,7 @@
     "name": "55 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000055654610",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63007,7 +63007,7 @@
     "name": "55 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000017495908",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63023,7 +63023,7 @@
     "name": "55 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000068557301",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63039,7 +63039,7 @@
     "name": "55 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000010993284",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63055,7 +63055,7 @@
     "name": "55 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000040089795",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63071,7 +63071,7 @@
     "name": "55 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000099020612",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63087,7 +63087,7 @@
     "name": "55 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000003183421",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63103,7 +63103,7 @@
     "name": "56 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000090727198",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63135,7 +63135,7 @@
     "name": "56 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000060024063",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63167,7 +63167,7 @@
     "name": "56 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000031976775",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63183,7 +63183,7 @@
     "name": "56 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000053142792",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63215,7 +63215,7 @@
     "name": "56 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000001580972",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63247,7 +63247,7 @@
     "name": "56 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000003113539",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63263,7 +63263,7 @@
     "name": "56 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000007429542",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63279,7 +63279,7 @@
     "name": "56 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000098791911",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63311,7 +63311,7 @@
     "name": "56 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000003094481",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63343,7 +63343,7 @@
     "name": "57 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000042402132",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63391,7 +63391,7 @@
     "name": "57 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000064446030",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63407,7 +63407,7 @@
     "name": "57 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000028897822",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63455,7 +63455,7 @@
     "name": "57 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000052480576",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63471,7 +63471,7 @@
     "name": "57 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000096298489",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63487,7 +63487,7 @@
     "name": "57 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000018404340",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63503,7 +63503,7 @@
     "name": "57 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000049424131",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63519,7 +63519,7 @@
     "name": "57 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000105046832",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63535,7 +63535,7 @@
     "name": "57 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000079786924",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63551,7 +63551,7 @@
     "name": "57A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000028629243",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63567,7 +63567,7 @@
     "name": "57B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000028897822",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63583,7 +63583,7 @@
     "name": "58 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000023313388",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63615,7 +63615,7 @@
     "name": "58 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000038009349",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63631,7 +63631,7 @@
     "name": "58 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000086821580",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63647,7 +63647,7 @@
     "name": "58 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000064664326",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63679,7 +63679,7 @@
     "name": "58 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000040229770",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63711,7 +63711,7 @@
     "name": "58 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000099882670",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63727,7 +63727,7 @@
     "name": "58 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000063978655",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63743,7 +63743,7 @@
     "name": "58 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000018420190",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63775,7 +63775,7 @@
     "name": "58 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000043763391",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63791,7 +63791,7 @@
     "name": "58A MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000099743927",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63823,7 +63823,7 @@
     "name": "59 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000095894041",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63871,7 +63871,7 @@
     "name": "59 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000019897669",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63887,7 +63887,7 @@
     "name": "59 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000033134331",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63935,7 +63935,7 @@
     "name": "59 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000090680924",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63951,7 +63951,7 @@
     "name": "59 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000059060516",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63967,7 +63967,7 @@
     "name": "59 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000083201236",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63983,7 +63983,7 @@
     "name": "59 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000100761466",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -63999,7 +63999,7 @@
     "name": "59 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000086568992",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64015,7 +64015,7 @@
     "name": "59 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000089989149",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64031,7 +64031,7 @@
     "name": "5A RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000030496719",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64047,7 +64047,7 @@
     "name": "5B RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000030986702",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64063,7 +64063,7 @@
     "name": "6 ABDALE CRESCENT GLENWOOD 2768",
     "locID": "LOC000078108899",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64079,7 +64079,7 @@
     "name": "6 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000027196335",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64095,7 +64095,7 @@
     "name": "6 AGINCOURT PLACE GLENWOOD 2768",
     "locID": "LOC000107266488",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64111,7 +64111,7 @@
     "name": "6 ALI PLACE GLENWOOD 2768",
     "locID": "LOC000028052124",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64143,7 +64143,7 @@
     "name": "6 ALPINE WAY GLENWOOD 2768",
     "locID": "LOC000073645613",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64159,7 +64159,7 @@
     "name": "6 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000052688958",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64175,7 +64175,7 @@
     "name": "6 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000035571583",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64191,7 +64191,7 @@
     "name": "6 AMUET PLACE GLENWOOD 2768",
     "locID": "LOC000087523167",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64223,7 +64223,7 @@
     "name": "6 ANGEL COURT GLENWOOD 2768",
     "locID": "LOC000061549714",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64239,7 +64239,7 @@
     "name": "6 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000104535038",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64255,7 +64255,7 @@
     "name": "6 ANITA STREET GLENWOOD 2768",
     "locID": "LOC000061684579",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64287,7 +64287,7 @@
     "name": "6 ARNIKA COURT GLENWOOD 2768",
     "locID": "LOC000122000212",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64319,7 +64319,7 @@
     "name": "6 ARROWSMITH STREET GLENWOOD 2768",
     "locID": "LOC000108326280",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64335,7 +64335,7 @@
     "name": "6 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000044132742",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64351,7 +64351,7 @@
     "name": "6 AVRIL COURT GLENWOOD 2768",
     "locID": "LOC000043607269",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64415,7 +64415,7 @@
     "name": "6 BEAUMONT AVENUE GLENWOOD 2768",
     "locID": "LOC000033149329",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64431,7 +64431,7 @@
     "name": "6 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000101811930",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64447,7 +64447,7 @@
     "name": "6 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000078324315",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64463,7 +64463,7 @@
     "name": "6 BETH WAY GLENWOOD 2768",
     "locID": "LOC000043225629",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64495,7 +64495,7 @@
     "name": "6 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000011910300",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64527,7 +64527,7 @@
     "name": "6 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000003134335",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64559,7 +64559,7 @@
     "name": "6 BRONTE AVENUE GLENWOOD 2768",
     "locID": "LOC000067562729",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64575,7 +64575,7 @@
     "name": "6 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000057578096",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64591,7 +64591,7 @@
     "name": "6 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000065419836",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64607,7 +64607,7 @@
     "name": "6 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000012238683",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64623,7 +64623,7 @@
     "name": "6 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000035410366",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64639,7 +64639,7 @@
     "name": "6 CAROONA WAY GLENWOOD 2768",
     "locID": "LOC000088284089",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64655,7 +64655,7 @@
     "name": "6 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000058550940",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64687,7 +64687,7 @@
     "name": "6 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000081695413",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64703,7 +64703,7 @@
     "name": "6 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000089517696",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64767,7 +64767,7 @@
     "name": "6 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000097788231",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64783,7 +64783,7 @@
     "name": "6 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000065213701",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64799,7 +64799,7 @@
     "name": "6 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000014847242",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64847,7 +64847,7 @@
     "name": "6 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000087466162",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64863,7 +64863,7 @@
     "name": "6 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000041928535",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64895,7 +64895,7 @@
     "name": "6 DARREN COURT GLENWOOD 2768",
     "locID": "LOC000055919253",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64927,7 +64927,7 @@
     "name": "6 DEAKIN AVENUE GLENWOOD 2768",
     "locID": "LOC000061286950",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64943,7 +64943,7 @@
     "name": "6 DENMAN COURT GLENWOOD 2768",
     "locID": "LOC000061360466",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64959,7 +64959,7 @@
     "name": "6 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000075454418",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64975,7 +64975,7 @@
     "name": "6 DIENELT CLOSE GLENWOOD 2768",
     "locID": "LOC000074849262",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -64991,7 +64991,7 @@
     "name": "6 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000064584268",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65023,7 +65023,7 @@
     "name": "6 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000012159935",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65039,7 +65039,7 @@
     "name": "6 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000018133473",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65071,7 +65071,7 @@
     "name": "6 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000087970155",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65103,7 +65103,7 @@
     "name": "6 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000015518189",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65119,7 +65119,7 @@
     "name": "6 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000013244419",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65151,7 +65151,7 @@
     "name": "6 FINCH PLACE GLENWOOD 2768",
     "locID": "LOC000101471418",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65183,7 +65183,7 @@
     "name": "6 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000109125104",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65199,7 +65199,7 @@
     "name": "6 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000052585064",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65215,7 +65215,7 @@
     "name": "6 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000181333960",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65231,7 +65231,7 @@
     "name": "6 GARNET GROVE GLENWOOD 2768",
     "locID": "LOC000105258067",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65279,7 +65279,7 @@
     "name": "6 GLENLEA COURT GLENWOOD 2768",
     "locID": "LOC000067792557",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65311,7 +65311,7 @@
     "name": "6 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000041519007",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65327,7 +65327,7 @@
     "name": "6 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000007307526",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65375,7 +65375,7 @@
     "name": "6 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000087771760",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65391,7 +65391,7 @@
     "name": "6 HAMBRO AVENUE GLENWOOD 2768",
     "locID": "LOC000032347469",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65407,7 +65407,7 @@
     "name": "6 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000046898259",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65423,7 +65423,7 @@
     "name": "6 HERITAGE PLACE GLENWOOD 2768",
     "locID": "LOC000014181265",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65439,7 +65439,7 @@
     "name": "6 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000099242640",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65455,7 +65455,7 @@
     "name": "6 HOYA WAY GLENWOOD 2768",
     "locID": "LOC000122000220",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65471,7 +65471,7 @@
     "name": "6 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000023905880",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65487,7 +65487,7 @@
     "name": "6 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000027140352",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65519,7 +65519,7 @@
     "name": "6 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000122000231",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65551,7 +65551,7 @@
     "name": "6 JOYCE STREET GLENWOOD 2768",
     "locID": "LOC000036776596",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65567,7 +65567,7 @@
     "name": "6 KANDOS STREET GLENWOOD 2768",
     "locID": "LOC000045060036",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65615,7 +65615,7 @@
     "name": "6 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000015983630",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65663,7 +65663,7 @@
     "name": "6 KOOKABURRA GROVE GLENWOOD 2768",
     "locID": "LOC000039171729",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65695,7 +65695,7 @@
     "name": "6 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000101888039",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65711,7 +65711,7 @@
     "name": "6 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000055911136",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65727,7 +65727,7 @@
     "name": "6 LEMON GROVE GLENWOOD 2768",
     "locID": "LOC000018808164",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65775,7 +65775,7 @@
     "name": "6 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000069145246",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65791,7 +65791,7 @@
     "name": "6 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000024601713",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65807,7 +65807,7 @@
     "name": "6 MAGPIE COURT GLENWOOD 2768",
     "locID": "LOC000122000249",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65839,7 +65839,7 @@
     "name": "6 MALEY GROVE GLENWOOD 2768",
     "locID": "LOC000021456410",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65855,7 +65855,7 @@
     "name": "6 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000100210116",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65871,7 +65871,7 @@
     "name": "6 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000040789839",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65887,7 +65887,7 @@
     "name": "6 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000075269135",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65903,7 +65903,7 @@
     "name": "6 MARS WAY GLENWOOD 2768",
     "locID": "LOC000011779098",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65935,7 +65935,7 @@
     "name": "6 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000065531819",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65951,7 +65951,7 @@
     "name": "6 MCMAHON GROVE GLENWOOD 2768",
     "locID": "LOC000026337025",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65983,7 +65983,7 @@
     "name": "6 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000018404340",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -65999,7 +65999,7 @@
     "name": "6 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000091982705",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66015,7 +66015,7 @@
     "name": "6 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000008137192",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66031,7 +66031,7 @@
     "name": "6 MINUET COURT GLENWOOD 2768",
     "locID": "LOC000024565093",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66063,7 +66063,7 @@
     "name": "6 MOULAMEIN TERRACE GLENWOOD 2768",
     "locID": "LOC000027159537",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66079,7 +66079,7 @@
     "name": "6 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000089193144",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66095,7 +66095,7 @@
     "name": "6 NESH PLACE GLENWOOD 2768",
     "locID": "LOC000122000254",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66111,7 +66111,7 @@
     "name": "6 NEWNES CLOSE GLENWOOD 2768",
     "locID": "LOC000080704967",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66127,7 +66127,7 @@
     "name": "6 NIXON STREET GLENWOOD 2768",
     "locID": "LOC000058519446",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66143,7 +66143,7 @@
     "name": "6 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000036141253",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66159,7 +66159,7 @@
     "name": "6 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000004605218",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66175,7 +66175,7 @@
     "name": "6 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000042817253",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66191,7 +66191,7 @@
     "name": "6 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000047782967",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66207,7 +66207,7 @@
     "name": "6 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000014636922",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66223,7 +66223,7 @@
     "name": "6 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000093443346",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66239,7 +66239,7 @@
     "name": "6 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000026291981",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66255,7 +66255,7 @@
     "name": "6 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000105111622",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66287,7 +66287,7 @@
     "name": "6 PERIDOT PLACE GLENWOOD 2768",
     "locID": "LOC000064558392",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66303,7 +66303,7 @@
     "name": "6 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000035597768",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66335,7 +66335,7 @@
     "name": "6 PINNACLE WAY GLENWOOD 2768",
     "locID": "LOC000034061817",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66351,7 +66351,7 @@
     "name": "6 PLUM GARDENS GLENWOOD 2768",
     "locID": "LOC000035896320",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66367,7 +66367,7 @@
     "name": "6 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000043634968",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66383,7 +66383,7 @@
     "name": "6 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000075411032",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66415,7 +66415,7 @@
     "name": "6 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000076187706",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66431,7 +66431,7 @@
     "name": "6 RAYWOOD COURT GLENWOOD 2768",
     "locID": "LOC000040975099",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66447,7 +66447,7 @@
     "name": "6 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000099604128",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66479,7 +66479,7 @@
     "name": "6 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000114851994",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66511,7 +66511,7 @@
     "name": "6 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000062087018",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66527,7 +66527,7 @@
     "name": "6 RYDER STREET GLENWOOD 2768",
     "locID": "LOC000055993948",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66591,7 +66591,7 @@
     "name": "6 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000039624574",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66607,7 +66607,7 @@
     "name": "6 SENTINEL STREET GLENWOOD 2768",
     "locID": "LOC000062839569",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66623,7 +66623,7 @@
     "name": "6 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000070540409",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66639,7 +66639,7 @@
     "name": "6 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000007166503",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66671,7 +66671,7 @@
     "name": "6 SILVERTON STREET GLENWOOD 2768",
     "locID": "LOC000043256550",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66703,7 +66703,7 @@
     "name": "6 SOLAR PLACE GLENWOOD 2768",
     "locID": "LOC000039058633",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66719,7 +66719,7 @@
     "name": "6 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000091122129",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66735,7 +66735,7 @@
     "name": "6 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000036278596",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66783,7 +66783,7 @@
     "name": "6 STRAWBERRY WAY GLENWOOD 2768",
     "locID": "LOC000085418411",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66799,7 +66799,7 @@
     "name": "6 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000044529089",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66815,7 +66815,7 @@
     "name": "6 SWANSEA COURT GLENWOOD 2768",
     "locID": "LOC000112956026",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66847,7 +66847,7 @@
     "name": "6 TANN-DARBY COURT GLENWOOD 2768",
     "locID": "LOC000061472191",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66863,7 +66863,7 @@
     "name": "6 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000045225846",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66879,7 +66879,7 @@
     "name": "6 TAWNY CLOSE GLENWOOD 2768",
     "locID": "LOC000101947458",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66895,7 +66895,7 @@
     "name": "6 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000092136030",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66927,7 +66927,7 @@
     "name": "6 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000080557395",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66943,7 +66943,7 @@
     "name": "6 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000114468537",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66959,7 +66959,7 @@
     "name": "6 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000091721602",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -66991,7 +66991,7 @@
     "name": "6 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000029169246",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67007,7 +67007,7 @@
     "name": "6 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000028982157",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67023,7 +67023,7 @@
     "name": "6 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000081772793",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67039,7 +67039,7 @@
     "name": "6 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000086914513",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67055,7 +67055,7 @@
     "name": "6 WILLOWLEAF CLOSE GLENWOOD 2768",
     "locID": "LOC000013080927",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67087,7 +67087,7 @@
     "name": "6 ZENITH COURT GLENWOOD 2768",
     "locID": "LOC000091191952",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67103,7 +67103,7 @@
     "name": "60 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000026529130",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67135,7 +67135,7 @@
     "name": "60 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000088236168",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67151,7 +67151,7 @@
     "name": "60 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000055031823",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67167,7 +67167,7 @@
     "name": "60 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000092502736",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67215,7 +67215,7 @@
     "name": "60 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000082965898",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67247,7 +67247,7 @@
     "name": "60 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000074625052",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67263,7 +67263,7 @@
     "name": "60 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000081162686",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67279,7 +67279,7 @@
     "name": "60 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000009732498",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67311,7 +67311,7 @@
     "name": "60 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000076309006",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67359,7 +67359,7 @@
     "name": "61 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000058550940",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67407,7 +67407,7 @@
     "name": "61 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000017918226",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67423,7 +67423,7 @@
     "name": "61 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000027356767",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67471,7 +67471,7 @@
     "name": "61 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000047995877",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67487,7 +67487,7 @@
     "name": "61 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000062087143",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67503,7 +67503,7 @@
     "name": "61 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000068436174",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67519,7 +67519,7 @@
     "name": "61 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000025956859",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67535,7 +67535,7 @@
     "name": "61 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000008737704",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67551,7 +67551,7 @@
     "name": "61 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000063230873",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67567,7 +67567,7 @@
     "name": "61A THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000001428417",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67583,7 +67583,7 @@
     "name": "61B THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000001510331",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67599,7 +67599,7 @@
     "name": "62 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000020921843",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67631,7 +67631,7 @@
     "name": "62 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000074477177",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67647,7 +67647,7 @@
     "name": "62 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000074739305",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67663,7 +67663,7 @@
     "name": "62 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000092124055",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67695,7 +67695,7 @@
     "name": "62 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000089310970",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67727,7 +67727,7 @@
     "name": "62 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000012362965",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67743,7 +67743,7 @@
     "name": "62 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000045870821",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67775,7 +67775,7 @@
     "name": "62 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000023026502",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67807,7 +67807,7 @@
     "name": "63 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000011382821",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67839,7 +67839,7 @@
     "name": "63 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000085158810",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67855,7 +67855,7 @@
     "name": "63 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000064830885",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67887,7 +67887,7 @@
     "name": "63 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000076867311",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67903,7 +67903,7 @@
     "name": "63 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000027178516",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67919,7 +67919,7 @@
     "name": "63 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000009717914",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67935,7 +67935,7 @@
     "name": "63 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000109938338",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67951,7 +67951,7 @@
     "name": "63 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000033118427",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67967,7 +67967,7 @@
     "name": "63 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000068963449",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -67983,7 +67983,7 @@
     "name": "64 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000028230097",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68015,7 +68015,7 @@
     "name": "64 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000010853518",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68031,7 +68031,7 @@
     "name": "64 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000084270688",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68063,7 +68063,7 @@
     "name": "64 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000074547877",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68095,7 +68095,7 @@
     "name": "64 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000024157499",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68111,7 +68111,7 @@
     "name": "64 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000099022397",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68159,7 +68159,7 @@
     "name": "65 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000085055822",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68191,7 +68191,7 @@
     "name": "65 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000086969201",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68223,7 +68223,7 @@
     "name": "65 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000068604310",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68239,7 +68239,7 @@
     "name": "65 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000047225354",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68255,7 +68255,7 @@
     "name": "65 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000064927847",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68271,7 +68271,7 @@
     "name": "65 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000035835686",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68287,7 +68287,7 @@
     "name": "65 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000005329284",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68319,7 +68319,7 @@
     "name": "66 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000091746948",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68351,7 +68351,7 @@
     "name": "66 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000046372496",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68367,7 +68367,7 @@
     "name": "66 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000057966952",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68383,7 +68383,7 @@
     "name": "66 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000100603798",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68415,7 +68415,7 @@
     "name": "66 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000010993189",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68431,7 +68431,7 @@
     "name": "66 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000011443663",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68479,7 +68479,7 @@
     "name": "67 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000074993919",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68511,7 +68511,7 @@
     "name": "67 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000075470519",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68543,7 +68543,7 @@
     "name": "67 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000013970926",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68559,7 +68559,7 @@
     "name": "67 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000022179765",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68575,7 +68575,7 @@
     "name": "67 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000045085860",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68591,7 +68591,7 @@
     "name": "67A THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000037128551",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68607,7 +68607,7 @@
     "name": "67B THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000037370112",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68623,7 +68623,7 @@
     "name": "68 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000099801481",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68655,7 +68655,7 @@
     "name": "68 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000075733242",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68671,7 +68671,7 @@
     "name": "68 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000088601246",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68687,7 +68687,7 @@
     "name": "68 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000051365724",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68719,7 +68719,7 @@
     "name": "68 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000007302422",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68735,7 +68735,7 @@
     "name": "68 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000096770662",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68767,7 +68767,7 @@
     "name": "69 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000080073019",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68799,7 +68799,7 @@
     "name": "69 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000092074535",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68831,7 +68831,7 @@
     "name": "69 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000015540863",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68847,7 +68847,7 @@
     "name": "69 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000084776837",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68863,7 +68863,7 @@
     "name": "69 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000014109209",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68895,7 +68895,7 @@
     "name": "6A PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000176129265",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68911,7 +68911,7 @@
     "name": "6A PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000177111141",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68927,7 +68927,7 @@
     "name": "6A RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000062087018",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68943,7 +68943,7 @@
     "name": "6B RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000062310948",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68959,7 +68959,7 @@
     "name": "7 ABDALE CRESCENT GLENWOOD 2768",
     "locID": "LOC000078608657",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68975,7 +68975,7 @@
     "name": "7 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000003284874",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -68991,7 +68991,7 @@
     "name": "7 AGINCOURT PLACE GLENWOOD 2768",
     "locID": "LOC000101957426",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69007,7 +69007,7 @@
     "name": "7 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000088589668",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69023,7 +69023,7 @@
     "name": "7 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000053534501",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69039,7 +69039,7 @@
     "name": "7 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000026402721",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69055,7 +69055,7 @@
     "name": "7 AMUET PLACE GLENWOOD 2768",
     "locID": "LOC000046843459",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69087,7 +69087,7 @@
     "name": "7 ANGEL COURT GLENWOOD 2768",
     "locID": "LOC000043200355",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69103,7 +69103,7 @@
     "name": "7 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000004742326",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69119,7 +69119,7 @@
     "name": "7 ANITA STREET GLENWOOD 2768",
     "locID": "LOC000075817639",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69151,7 +69151,7 @@
     "name": "7 ARNIKA COURT GLENWOOD 2768",
     "locID": "LOC000122000323",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69199,7 +69199,7 @@
     "name": "7 ARROWSMITH STREET GLENWOOD 2768",
     "locID": "LOC000028255144",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69215,7 +69215,7 @@
     "name": "7 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000153913593",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69263,7 +69263,7 @@
     "name": "7 BEAUMONT AVENUE GLENWOOD 2768",
     "locID": "LOC000043790037",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69279,7 +69279,7 @@
     "name": "7 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000051996140",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69295,7 +69295,7 @@
     "name": "7 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000042013629",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69327,7 +69327,7 @@
     "name": "7 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000018813207",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69343,7 +69343,7 @@
     "name": "7 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000097604631",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69375,7 +69375,7 @@
     "name": "7 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000083738022",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69407,7 +69407,7 @@
     "name": "7 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000068455882",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69423,7 +69423,7 @@
     "name": "7 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000089390622",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69439,7 +69439,7 @@
     "name": "7 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000043570262",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69455,7 +69455,7 @@
     "name": "7 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000041874070",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69471,7 +69471,7 @@
     "name": "7 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000024836833",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69487,7 +69487,7 @@
     "name": "7 CAROONA WAY GLENWOOD 2768",
     "locID": "LOC000070754797",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69503,7 +69503,7 @@
     "name": "7 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000082894200",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69519,7 +69519,7 @@
     "name": "7 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000100211155",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69567,7 +69567,7 @@
     "name": "7 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000057085876",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69615,7 +69615,7 @@
     "name": "7 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000076722852",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69631,7 +69631,7 @@
     "name": "7 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000009659239",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69647,7 +69647,7 @@
     "name": "7 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000049721038",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69679,7 +69679,7 @@
     "name": "7 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000090322949",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69695,7 +69695,7 @@
     "name": "7 DEAKIN AVENUE GLENWOOD 2768",
     "locID": "LOC000060226386",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69711,7 +69711,7 @@
     "name": "7 DENMAN COURT GLENWOOD 2768",
     "locID": "LOC000019712285",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69727,7 +69727,7 @@
     "name": "7 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000023994943",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69743,7 +69743,7 @@
     "name": "7 DIENELT CLOSE GLENWOOD 2768",
     "locID": "LOC000084135406",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69759,7 +69759,7 @@
     "name": "7 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000096532115",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69775,7 +69775,7 @@
     "name": "7 EAGLE WAY GLENWOOD 2768",
     "locID": "LOC000063827566",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69823,7 +69823,7 @@
     "name": "7 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000028679916",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69839,7 +69839,7 @@
     "name": "7 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000057698624",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69871,7 +69871,7 @@
     "name": "7 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000084084795",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69903,7 +69903,7 @@
     "name": "7 EUREKA GROVE GLENWOOD 2768",
     "locID": "LOC000004714068",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69919,7 +69919,7 @@
     "name": "7 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000052712773",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69935,7 +69935,7 @@
     "name": "7 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000027856873",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69967,7 +69967,7 @@
     "name": "7 FIG TERRACE GLENWOOD 2768",
     "locID": "LOC000026386403",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -69983,7 +69983,7 @@
     "name": "7 FINCH PLACE GLENWOOD 2768",
     "locID": "LOC000015879855",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70015,7 +70015,7 @@
     "name": "7 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000052107501",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70031,7 +70031,7 @@
     "name": "7 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000052434081",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70047,7 +70047,7 @@
     "name": "7 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000108539486",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70063,7 +70063,7 @@
     "name": "7 GARNET GROVE GLENWOOD 2768",
     "locID": "LOC000065418485",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70111,7 +70111,7 @@
     "name": "7 GLENLEA COURT GLENWOOD 2768",
     "locID": "LOC000055746086",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70143,7 +70143,7 @@
     "name": "7 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000046073228",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70159,7 +70159,7 @@
     "name": "7 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000053801478",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70175,7 +70175,7 @@
     "name": "7 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000035578747",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70223,7 +70223,7 @@
     "name": "7 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000065438541",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70239,7 +70239,7 @@
     "name": "7 HAMBRO AVENUE GLENWOOD 2768",
     "locID": "LOC000103176567",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70255,7 +70255,7 @@
     "name": "7 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000087961039",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70271,7 +70271,7 @@
     "name": "7 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000089158917",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70303,7 +70303,7 @@
     "name": "7 HONEYEATER TERRACE GLENWOOD 2768",
     "locID": "LOC000027214222",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70319,7 +70319,7 @@
     "name": "7 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000010512661",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70351,7 +70351,7 @@
     "name": "7 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000122000334",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70383,7 +70383,7 @@
     "name": "7 JOYCE STREET GLENWOOD 2768",
     "locID": "LOC000072957973",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70399,7 +70399,7 @@
     "name": "7 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000033028053",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70431,7 +70431,7 @@
     "name": "7 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000024082863",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70447,7 +70447,7 @@
     "name": "7 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000010548330",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70463,7 +70463,7 @@
     "name": "7 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000034653429",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70479,7 +70479,7 @@
     "name": "7 KOOKABURRA GROVE GLENWOOD 2768",
     "locID": "LOC000013299900",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70495,7 +70495,7 @@
     "name": "7 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000067679151",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70511,7 +70511,7 @@
     "name": "7 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000098847412",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70527,7 +70527,7 @@
     "name": "7 LEMON GROVE GLENWOOD 2768",
     "locID": "LOC000034056889",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70559,7 +70559,7 @@
     "name": "7 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000026363506",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70575,7 +70575,7 @@
     "name": "7 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000086076777",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70607,7 +70607,7 @@
     "name": "7 MALEY GROVE GLENWOOD 2768",
     "locID": "LOC000026323355",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70623,7 +70623,7 @@
     "name": "7 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000153932648",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70639,7 +70639,7 @@
     "name": "7 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000043933075",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70655,7 +70655,7 @@
     "name": "7 MARS WAY GLENWOOD 2768",
     "locID": "LOC000043515199",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70671,7 +70671,7 @@
     "name": "7 MATARA WAY GLENWOOD 2768",
     "locID": "LOC000004187910",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70687,7 +70687,7 @@
     "name": "7 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000074647630",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70703,7 +70703,7 @@
     "name": "7 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000023856468",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70719,7 +70719,7 @@
     "name": "7 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000013220883",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70735,7 +70735,7 @@
     "name": "7 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000105363885",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70751,7 +70751,7 @@
     "name": "7 MINUET COURT GLENWOOD 2768",
     "locID": "LOC000084332882",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70799,7 +70799,7 @@
     "name": "7 MUSCAT GROVE GLENWOOD 2768",
     "locID": "LOC000082594923",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70815,7 +70815,7 @@
     "name": "7 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000088045795",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70831,7 +70831,7 @@
     "name": "7 NESH PLACE GLENWOOD 2768",
     "locID": "LOC000122000347",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70847,7 +70847,7 @@
     "name": "7 NEWNES CLOSE GLENWOOD 2768",
     "locID": "LOC000028904324",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70863,7 +70863,7 @@
     "name": "7 NIXON STREET GLENWOOD 2768",
     "locID": "LOC000014590694",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70879,7 +70879,7 @@
     "name": "7 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000025563686",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70895,7 +70895,7 @@
     "name": "7 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000105359456",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70911,7 +70911,7 @@
     "name": "7 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000029653918",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70927,7 +70927,7 @@
     "name": "7 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000014686568",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70943,7 +70943,7 @@
     "name": "7 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000062087087",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70959,7 +70959,7 @@
     "name": "7 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000045919970",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70975,7 +70975,7 @@
     "name": "7 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000067645546",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -70991,7 +70991,7 @@
     "name": "7 PEACH GARDENS GLENWOOD 2768",
     "locID": "LOC000043612418",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71007,7 +71007,7 @@
     "name": "7 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000065074564",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71039,7 +71039,7 @@
     "name": "7 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000001443399",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71087,7 +71087,7 @@
     "name": "7 PINNACLE WAY GLENWOOD 2768",
     "locID": "LOC000054525090",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71103,7 +71103,7 @@
     "name": "7 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000019672702",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71119,7 +71119,7 @@
     "name": "7 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000057498265",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71135,7 +71135,7 @@
     "name": "7 POPPY WAY GLENWOOD 2768",
     "locID": "LOC000122000352",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71151,7 +71151,7 @@
     "name": "7 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000066426899",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71183,7 +71183,7 @@
     "name": "7 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000045697388",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71199,7 +71199,7 @@
     "name": "7 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000113041661",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71231,7 +71231,7 @@
     "name": "7 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000090424062",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71279,7 +71279,7 @@
     "name": "7 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000031284291",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71295,7 +71295,7 @@
     "name": "7 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000059170921",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71311,7 +71311,7 @@
     "name": "7 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000075779586",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71327,7 +71327,7 @@
     "name": "7 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000107392928",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71407,7 +71407,7 @@
     "name": "7 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000057180168",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71423,7 +71423,7 @@
     "name": "7 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000017158682",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71455,7 +71455,7 @@
     "name": "7 STRAWBERRY WAY GLENWOOD 2768",
     "locID": "LOC000006345420",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71471,7 +71471,7 @@
     "name": "7 SULTANA GROVE GLENWOOD 2768",
     "locID": "LOC000078688104",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71487,7 +71487,7 @@
     "name": "7 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000036984063",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71519,7 +71519,7 @@
     "name": "7 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000022466723",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71535,7 +71535,7 @@
     "name": "7 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000002197974",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71567,7 +71567,7 @@
     "name": "7 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000114469082",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71583,7 +71583,7 @@
     "name": "7 WALTHAM WAY GLENWOOD 2768",
     "locID": "LOC000058817924",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71599,7 +71599,7 @@
     "name": "7 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000079934001",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71615,7 +71615,7 @@
     "name": "7 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000082917461",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71647,7 +71647,7 @@
     "name": "7 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000060933265",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71663,7 +71663,7 @@
     "name": "7 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000045258201",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71679,7 +71679,7 @@
     "name": "7 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000095912308",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71695,7 +71695,7 @@
     "name": "7 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000068654030",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71711,7 +71711,7 @@
     "name": "7 WILLOWLEAF CLOSE GLENWOOD 2768",
     "locID": "LOC000043009813",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71727,7 +71727,7 @@
     "name": "7 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000042251829",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71743,7 +71743,7 @@
     "name": "7 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000030124522",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71775,7 +71775,7 @@
     "name": "7 ZENITH COURT GLENWOOD 2768",
     "locID": "LOC000082676088",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71791,7 +71791,7 @@
     "name": "70 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000051954192",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71823,7 +71823,7 @@
     "name": "70 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000078519552",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71839,7 +71839,7 @@
     "name": "70 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000007321333",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71887,7 +71887,7 @@
     "name": "71 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000096397520",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71919,7 +71919,7 @@
     "name": "71 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000087553276",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71951,7 +71951,7 @@
     "name": "71 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000042023742",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71967,7 +71967,7 @@
     "name": "71 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000036404114",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -71983,7 +71983,7 @@
     "name": "71 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000038036998",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72031,7 +72031,7 @@
     "name": "72 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000082725727",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72047,7 +72047,7 @@
     "name": "72 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000122003070",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72063,7 +72063,7 @@
     "name": "72 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000010512661",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72095,7 +72095,7 @@
     "name": "72 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000078210762",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72127,7 +72127,7 @@
     "name": "73 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000045346014",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72159,7 +72159,7 @@
     "name": "73 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000011305100",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72191,7 +72191,7 @@
     "name": "73 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000001578753",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72207,7 +72207,7 @@
     "name": "73 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000096237971",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72223,7 +72223,7 @@
     "name": "73 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000078835329",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72239,7 +72239,7 @@
     "name": "74 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000097752184",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72271,7 +72271,7 @@
     "name": "74 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000014788459",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72287,7 +72287,7 @@
     "name": "74 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000109838432",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72319,7 +72319,7 @@
     "name": "74 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000026310062",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72383,7 +72383,7 @@
     "name": "75 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000023798813",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72415,7 +72415,7 @@
     "name": "75 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000049659125",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72431,7 +72431,7 @@
     "name": "75 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000004667058",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72447,7 +72447,7 @@
     "name": "75 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000037939181",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72463,7 +72463,7 @@
     "name": "76 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000027390109",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72495,7 +72495,7 @@
     "name": "76 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000049772889",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72511,7 +72511,7 @@
     "name": "76 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000087572333",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72543,7 +72543,7 @@
     "name": "76 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000010451421",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72591,7 +72591,7 @@
     "name": "77 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000006283843",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72623,7 +72623,7 @@
     "name": "77 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000090184816",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72639,7 +72639,7 @@
     "name": "77 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000022245856",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72655,7 +72655,7 @@
     "name": "78 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000061252826",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72687,7 +72687,7 @@
     "name": "78 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000078182428",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72703,7 +72703,7 @@
     "name": "78 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000092470625",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72735,7 +72735,7 @@
     "name": "78 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000099954243",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72783,7 +72783,7 @@
     "name": "79 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000037143319",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72815,7 +72815,7 @@
     "name": "79 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000004241191",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72831,7 +72831,7 @@
     "name": "79 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000062546075",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72847,7 +72847,7 @@
     "name": "7A NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000191602323",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72863,7 +72863,7 @@
     "name": "8 ABDALE CRESCENT GLENWOOD 2768",
     "locID": "LOC000075527954",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72879,7 +72879,7 @@
     "name": "8 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000104367883",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72895,7 +72895,7 @@
     "name": "8 AGINCOURT PLACE GLENWOOD 2768",
     "locID": "LOC000075543533",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72911,7 +72911,7 @@
     "name": "8 ALI PLACE GLENWOOD 2768",
     "locID": "LOC000068497409",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72927,7 +72927,7 @@
     "name": "8 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000041739569",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72943,7 +72943,7 @@
     "name": "8 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000011376895",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72959,7 +72959,7 @@
     "name": "8 AMUET PLACE GLENWOOD 2768",
     "locID": "LOC000043538624",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -72991,7 +72991,7 @@
     "name": "8 ANGEL COURT GLENWOOD 2768",
     "locID": "LOC000065498515",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73007,7 +73007,7 @@
     "name": "8 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000028760474",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73023,7 +73023,7 @@
     "name": "8 ANITA STREET GLENWOOD 2768",
     "locID": "LOC000072371393",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73055,7 +73055,7 @@
     "name": "8 ARNIKA COURT GLENWOOD 2768",
     "locID": "LOC000122003089",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73087,7 +73087,7 @@
     "name": "8 ARROWSMITH STREET GLENWOOD 2768",
     "locID": "LOC000011382747",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73103,7 +73103,7 @@
     "name": "8 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000088177635",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73151,7 +73151,7 @@
     "name": "8 BEAUMONT AVENUE GLENWOOD 2768",
     "locID": "LOC000096973304",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73167,7 +73167,7 @@
     "name": "8 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000014781374",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73183,7 +73183,7 @@
     "name": "8 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000008328890",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73199,7 +73199,7 @@
     "name": "8 BETH WAY GLENWOOD 2768",
     "locID": "LOC000063131854",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73231,7 +73231,7 @@
     "name": "8 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000055437326",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73263,7 +73263,7 @@
     "name": "8 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000083013774",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73279,7 +73279,7 @@
     "name": "8 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000183454844",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73295,7 +73295,7 @@
     "name": "8 BRONTE AVENUE GLENWOOD 2768",
     "locID": "LOC000070555251",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73311,7 +73311,7 @@
     "name": "8 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000062776779",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73327,7 +73327,7 @@
     "name": "8 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000075288293",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73343,7 +73343,7 @@
     "name": "8 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000089150320",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73359,7 +73359,7 @@
     "name": "8 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000051788419",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73375,7 +73375,7 @@
     "name": "8 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000066446407",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73391,7 +73391,7 @@
     "name": "8 CAROONA WAY GLENWOOD 2768",
     "locID": "LOC000076753558",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73407,7 +73407,7 @@
     "name": "8 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000036624541",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73423,7 +73423,7 @@
     "name": "8 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000045308192",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73471,7 +73471,7 @@
     "name": "8 CHELSEA TERRACE GLENWOOD 2768",
     "locID": "LOC000066646439",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73487,7 +73487,7 @@
     "name": "8 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000010538585",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73535,7 +73535,7 @@
     "name": "8 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000089434883",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73551,7 +73551,7 @@
     "name": "8 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000048061616",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73567,7 +73567,7 @@
     "name": "8 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000069146557",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73599,7 +73599,7 @@
     "name": "8 CURRAWONG STREET GLENWOOD 2768",
     "locID": "LOC000092398404",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73615,7 +73615,7 @@
     "name": "8 DARREN COURT GLENWOOD 2768",
     "locID": "LOC000095837665",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73631,7 +73631,7 @@
     "name": "8 DEAKIN AVENUE GLENWOOD 2768",
     "locID": "LOC000099611626",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73647,7 +73647,7 @@
     "name": "8 DENMAN COURT GLENWOOD 2768",
     "locID": "LOC000086002425",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73663,7 +73663,7 @@
     "name": "8 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000043760076",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73679,7 +73679,7 @@
     "name": "8 DIENELT CLOSE GLENWOOD 2768",
     "locID": "LOC000080009267",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73695,7 +73695,7 @@
     "name": "8 DRAPER STREET GLENWOOD 2768",
     "locID": "LOC000093334134",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73727,7 +73727,7 @@
     "name": "8 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000074742372",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73743,7 +73743,7 @@
     "name": "8 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000022943167",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73775,7 +73775,7 @@
     "name": "8 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000032279694",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73807,7 +73807,7 @@
     "name": "8 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000103174078",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73823,7 +73823,7 @@
     "name": "8 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000084126968",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73855,7 +73855,7 @@
     "name": "8 FINCH PLACE GLENWOOD 2768",
     "locID": "LOC000066493298",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73887,7 +73887,7 @@
     "name": "8 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000026359945",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73903,7 +73903,7 @@
     "name": "8 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000014027310",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73919,7 +73919,7 @@
     "name": "8 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000055864782",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73935,7 +73935,7 @@
     "name": "8 GARNET GROVE GLENWOOD 2768",
     "locID": "LOC000002987934",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73967,7 +73967,7 @@
     "name": "8 GLENLEA COURT GLENWOOD 2768",
     "locID": "LOC000088353660",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -73999,7 +73999,7 @@
     "name": "8 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000028009614",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74015,7 +74015,7 @@
     "name": "8 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000031386109",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74031,7 +74031,7 @@
     "name": "8 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000070606089",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74079,7 +74079,7 @@
     "name": "8 HADDON CLOSE GLENWOOD 2768",
     "locID": "LOC000091226030",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74095,7 +74095,7 @@
     "name": "8 HAMBRO AVENUE GLENWOOD 2768",
     "locID": "LOC000086760247",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74111,7 +74111,7 @@
     "name": "8 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000065036335",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74127,7 +74127,7 @@
     "name": "8 HERITAGE PLACE GLENWOOD 2768",
     "locID": "LOC000078623959",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74143,7 +74143,7 @@
     "name": "8 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000045346261",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74175,7 +74175,7 @@
     "name": "8 HOYA WAY GLENWOOD 2768",
     "locID": "LOC000122003091",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74191,7 +74191,7 @@
     "name": "8 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000097043654",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74223,7 +74223,7 @@
     "name": "8 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000122003101",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74255,7 +74255,7 @@
     "name": "8 JOYCE STREET GLENWOOD 2768",
     "locID": "LOC000014678789",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74271,7 +74271,7 @@
     "name": "8 KANDOS STREET GLENWOOD 2768",
     "locID": "LOC000101113995",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74319,7 +74319,7 @@
     "name": "8 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000048084621",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74335,7 +74335,7 @@
     "name": "8 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000094669356",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74367,7 +74367,7 @@
     "name": "8 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000077119456",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74383,7 +74383,7 @@
     "name": "8 KOOKABURRA GROVE GLENWOOD 2768",
     "locID": "LOC000062936170",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74399,7 +74399,7 @@
     "name": "8 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000011379405",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74415,7 +74415,7 @@
     "name": "8 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000039851877",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74431,7 +74431,7 @@
     "name": "8 LEMON GROVE GLENWOOD 2768",
     "locID": "LOC000015886912",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74479,7 +74479,7 @@
     "name": "8 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000077811214",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74495,7 +74495,7 @@
     "name": "8 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000090221680",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74511,7 +74511,7 @@
     "name": "8 MAGPIE COURT GLENWOOD 2768",
     "locID": "LOC000122003117",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74543,7 +74543,7 @@
     "name": "8 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000094640493",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74559,7 +74559,7 @@
     "name": "8 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000064544498",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74575,7 +74575,7 @@
     "name": "8 MARIE AVENUE GLENWOOD 2768",
     "locID": "LOC000055705726",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74591,7 +74591,7 @@
     "name": "8 MARS WAY GLENWOOD 2768",
     "locID": "LOC000079088315",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74623,7 +74623,7 @@
     "name": "8 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000068185384",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74655,7 +74655,7 @@
     "name": "8 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000026398756",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74671,7 +74671,7 @@
     "name": "8 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000100049237",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74687,7 +74687,7 @@
     "name": "8 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000042523136",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74703,7 +74703,7 @@
     "name": "8 MINUET COURT GLENWOOD 2768",
     "locID": "LOC000090356699",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74719,7 +74719,7 @@
     "name": "8 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000036610615",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74735,7 +74735,7 @@
     "name": "8 NESH PLACE GLENWOOD 2768",
     "locID": "LOC000122003129",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74751,7 +74751,7 @@
     "name": "8 NEWNES CLOSE GLENWOOD 2768",
     "locID": "LOC000098195487",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74767,7 +74767,7 @@
     "name": "8 NIXON STREET GLENWOOD 2768",
     "locID": "LOC000010551786",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74783,7 +74783,7 @@
     "name": "8 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000036326358",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74799,7 +74799,7 @@
     "name": "8 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000102108092",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74815,7 +74815,7 @@
     "name": "8 OAKLEAF AVENUE GLENWOOD 2768",
     "locID": "LOC000048100442",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74831,7 +74831,7 @@
     "name": "8 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000018042153",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74847,7 +74847,7 @@
     "name": "8 PACKSADDLE STREET GLENWOOD 2768",
     "locID": "LOC000098750367",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74863,7 +74863,7 @@
     "name": "8 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000006491851",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74879,7 +74879,7 @@
     "name": "8 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000086586341",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74895,7 +74895,7 @@
     "name": "8 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000089934988",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74927,7 +74927,7 @@
     "name": "8 PERIDOT PLACE GLENWOOD 2768",
     "locID": "LOC000022217655",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74943,7 +74943,7 @@
     "name": "8 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000065484925",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74975,7 +74975,7 @@
     "name": "8 PINNACLE WAY GLENWOOD 2768",
     "locID": "LOC000039022278",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -74991,7 +74991,7 @@
     "name": "8 PLUM GARDENS GLENWOOD 2768",
     "locID": "LOC000043196713",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75007,7 +75007,7 @@
     "name": "8 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000046323027",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75023,7 +75023,7 @@
     "name": "8 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000046355101",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75039,7 +75039,7 @@
     "name": "8 RACHAEL PLACE GLENWOOD 2768",
     "locID": "LOC000086078516",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75055,7 +75055,7 @@
     "name": "8 RAYWOOD COURT GLENWOOD 2768",
     "locID": "LOC000079034321",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75071,7 +75071,7 @@
     "name": "8 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000072754789",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75103,7 +75103,7 @@
     "name": "8 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000112860206",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75135,7 +75135,7 @@
     "name": "8 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000070511508",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75199,7 +75199,7 @@
     "name": "8 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000011270545",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75215,7 +75215,7 @@
     "name": "8 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000107439298",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75263,7 +75263,7 @@
     "name": "8 SOLAR PLACE GLENWOOD 2768",
     "locID": "LOC000075621180",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75279,7 +75279,7 @@
     "name": "8 SOPHIE PLACE GLENWOOD 2768",
     "locID": "LOC000093415009",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75295,7 +75295,7 @@
     "name": "8 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000006555423",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75311,7 +75311,7 @@
     "name": "8 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000107261196",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75343,7 +75343,7 @@
     "name": "8 STRAWBERRY WAY GLENWOOD 2768",
     "locID": "LOC000047653480",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75359,7 +75359,7 @@
     "name": "8 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000088339706",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75375,7 +75375,7 @@
     "name": "8 SWANSEA COURT GLENWOOD 2768",
     "locID": "LOC000112803101",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75407,7 +75407,7 @@
     "name": "8 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000007237792",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75423,7 +75423,7 @@
     "name": "8 TAWNY CLOSE GLENWOOD 2768",
     "locID": "LOC000023097349",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75439,7 +75439,7 @@
     "name": "8 TEAWA CRESCENT GLENWOOD 2768",
     "locID": "LOC000043662857",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75471,7 +75471,7 @@
     "name": "8 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000093500579",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75487,7 +75487,7 @@
     "name": "8 WARDIA STREET GLENWOOD 2768",
     "locID": "LOC000081006966",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75519,7 +75519,7 @@
     "name": "8 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000007213666",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75535,7 +75535,7 @@
     "name": "8 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000002378376",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75551,7 +75551,7 @@
     "name": "8 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000055670789",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75567,7 +75567,7 @@
     "name": "8 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000046951809",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75583,7 +75583,7 @@
     "name": "8 WILLOWLEAF CLOSE GLENWOOD 2768",
     "locID": "LOC000030433945",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75599,7 +75599,7 @@
     "name": "8 WILLOWTREE AVENUE GLENWOOD 2768",
     "locID": "LOC000083757347",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75647,7 +75647,7 @@
     "name": "80 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000076417172",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75679,7 +75679,7 @@
     "name": "80 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000016487032",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75695,7 +75695,7 @@
     "name": "80 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000101597198",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75727,7 +75727,7 @@
     "name": "80 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000004686552",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75775,7 +75775,7 @@
     "name": "81 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000009002901",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75805,7 +75805,7 @@
    },
    "properties": {
     "name": "81 MEURANTS LANE GLENWOOD 2768",
-    "locID": "LOC000190426502",
+    "locID": "LOC000190426518",
     "tech": "FTTN",
     "upgrade": "NULL_NA"
    }
@@ -75823,7 +75823,7 @@
     "name": "81 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000062232014",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75839,7 +75839,7 @@
     "name": "82 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000071094710",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75871,7 +75871,7 @@
     "name": "82 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000086593703",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75887,7 +75887,7 @@
     "name": "82 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000015600032",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75903,7 +75903,7 @@
     "name": "82 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000008164686",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75919,7 +75919,7 @@
     "name": "82 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000081007959",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75951,7 +75951,7 @@
     "name": "82 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000054490129",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -75967,7 +75967,7 @@
     "name": "82A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000187281260",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76015,7 +76015,7 @@
     "name": "83 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000072262457",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76047,7 +76047,7 @@
     "name": "83 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000015014873",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76063,7 +76063,7 @@
     "name": "84 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000071147391",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76095,7 +76095,7 @@
     "name": "84 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000065104734",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76111,7 +76111,7 @@
     "name": "84 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000042045030",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76127,7 +76127,7 @@
     "name": "84 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000095712120",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76159,7 +76159,7 @@
     "name": "84 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000097938437",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76207,7 +76207,7 @@
     "name": "85 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000154754828",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76223,7 +76223,7 @@
     "name": "85 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000057953041",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76255,7 +76255,7 @@
     "name": "85 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000063582819",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76271,7 +76271,7 @@
     "name": "86 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000053142771",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76303,7 +76303,7 @@
     "name": "86 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000073281908",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76319,7 +76319,7 @@
     "name": "86 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000009724627",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76335,7 +76335,7 @@
     "name": "86 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000099850543",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76367,7 +76367,7 @@
     "name": "86 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000028105322",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76415,7 +76415,7 @@
     "name": "87 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000098960671",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76447,7 +76447,7 @@
     "name": "87 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000090362689",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76463,7 +76463,7 @@
     "name": "87 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000045940084",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76479,7 +76479,7 @@
     "name": "87A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000170850847",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76495,7 +76495,7 @@
     "name": "88 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000014665200",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76511,7 +76511,7 @@
     "name": "88 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000015584197",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76527,7 +76527,7 @@
     "name": "88 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000045356358",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76543,7 +76543,7 @@
     "name": "88 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000103242079",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76575,7 +76575,7 @@
     "name": "88 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000032302225",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76623,7 +76623,7 @@
     "name": "89 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000082676061",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76655,7 +76655,7 @@
     "name": "89 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000028768373",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76671,7 +76671,7 @@
     "name": "89 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000010509617",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76687,7 +76687,7 @@
     "name": "89A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000176180118",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76703,7 +76703,7 @@
     "name": "9 ADRIAN STREET GLENWOOD 2768",
     "locID": "LOC000048533909",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76719,7 +76719,7 @@
     "name": "9 AGINCOURT PLACE GLENWOOD 2768",
     "locID": "LOC000002265333",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76735,7 +76735,7 @@
     "name": "9 ALICIA STREET GLENWOOD 2768",
     "locID": "LOC000027105209",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76751,7 +76751,7 @@
     "name": "9 ALWYN CRESCENT GLENWOOD 2768",
     "locID": "LOC000052607502",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76767,7 +76767,7 @@
     "name": "9 AMBERLEA STREET GLENWOOD 2768",
     "locID": "LOC000039922538",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76783,7 +76783,7 @@
     "name": "9 AMUET PLACE GLENWOOD 2768",
     "locID": "LOC000041924253",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76815,7 +76815,7 @@
     "name": "9 ANGEL COURT GLENWOOD 2768",
     "locID": "LOC000077592784",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76831,7 +76831,7 @@
     "name": "9 ANGELA CLOSE GLENWOOD 2768",
     "locID": "LOC000037394545",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76847,7 +76847,7 @@
     "name": "9 ANITA STREET GLENWOOD 2768",
     "locID": "LOC000089114521",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76879,7 +76879,7 @@
     "name": "9 ARNIKA COURT GLENWOOD 2768",
     "locID": "LOC000122003138",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76927,7 +76927,7 @@
     "name": "9 AVONLEIGH COURT GLENWOOD 2768",
     "locID": "LOC000153913604",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76975,7 +76975,7 @@
     "name": "9 BEAUMONT AVENUE GLENWOOD 2768",
     "locID": "LOC000090388849",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -76991,7 +76991,7 @@
     "name": "9 BELINDA CRESCENT GLENWOOD 2768",
     "locID": "LOC000080226644",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77007,7 +77007,7 @@
     "name": "9 BELLENDEN CLOSE GLENWOOD 2768",
     "locID": "LOC000087919446",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77039,7 +77039,7 @@
     "name": "9 BITTERN GROVE GLENWOOD 2768",
     "locID": "LOC000035939078",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77055,7 +77055,7 @@
     "name": "9 BLUEBERRY GROVE GLENWOOD 2768",
     "locID": "LOC000070837640",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77087,7 +77087,7 @@
     "name": "9 BLYTHE AVENUE GLENWOOD 2768",
     "locID": "LOC000107535838",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77103,7 +77103,7 @@
     "name": "9 BOONDEROO AVENUE GLENWOOD 2768",
     "locID": "LOC000153916152",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77119,7 +77119,7 @@
     "name": "9 BRUSHBOX CLOSE GLENWOOD 2768",
     "locID": "LOC000015372621",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77135,7 +77135,7 @@
     "name": "9 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000010513013",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77151,7 +77151,7 @@
     "name": "9 CALEEN STREET GLENWOOD 2768",
     "locID": "LOC000099714658",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77167,7 +77167,7 @@
     "name": "9 CAMEO CIRCUIT GLENWOOD 2768",
     "locID": "LOC000033872329",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77183,7 +77183,7 @@
     "name": "9 CANTWELL STREET GLENWOOD 2768",
     "locID": "LOC000035753419",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77215,7 +77215,7 @@
     "name": "9 CARROWBROOK AVENUE GLENWOOD 2768",
     "locID": "LOC000041452996",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77231,7 +77231,7 @@
     "name": "9 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000020417835",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77279,7 +77279,7 @@
     "name": "9 CHERRYWOOD STREET GLENWOOD 2768",
     "locID": "LOC000066498903",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77327,7 +77327,7 @@
     "name": "9 COOKSON PLACE GLENWOOD 2768",
     "locID": "LOC000027349303",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77343,7 +77343,7 @@
     "name": "9 COOYAL PLACE GLENWOOD 2768",
     "locID": "LOC000099108086",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77359,7 +77359,7 @@
     "name": "9 CRAMER PLACE GLENWOOD 2768",
     "locID": "LOC000067548060",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77391,7 +77391,7 @@
     "name": "9 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000030055245",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77407,7 +77407,7 @@
     "name": "9 DEAKIN AVENUE GLENWOOD 2768",
     "locID": "LOC000043872148",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77423,7 +77423,7 @@
     "name": "9 DENMAN COURT GLENWOOD 2768",
     "locID": "LOC000101136478",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77439,7 +77439,7 @@
     "name": "9 DIAMOND AVENUE GLENWOOD 2768",
     "locID": "LOC000022969745",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77455,7 +77455,7 @@
     "name": "9 EAGLE WAY GLENWOOD 2768",
     "locID": "LOC000003065535",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77487,7 +77487,7 @@
     "name": "9 EMMA GROVE GLENWOOD 2768",
     "locID": "LOC000035519072",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77503,7 +77503,7 @@
     "name": "9 EMMANUEL TERRACE GLENWOOD 2768",
     "locID": "LOC000040321478",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77535,7 +77535,7 @@
     "name": "9 ERNEST STREET GLENWOOD 2768",
     "locID": "LOC000090458961",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77567,7 +77567,7 @@
     "name": "9 EUREKA GROVE GLENWOOD 2768",
     "locID": "LOC000076906176",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77583,7 +77583,7 @@
     "name": "9 FALCON WAY GLENWOOD 2768",
     "locID": "LOC000064281816",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77599,7 +77599,7 @@
     "name": "9 FARMER CLOSE GLENWOOD 2768",
     "locID": "LOC000047972611",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77631,7 +77631,7 @@
     "name": "9 FIG TERRACE GLENWOOD 2768",
     "locID": "LOC000055625309",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77663,7 +77663,7 @@
     "name": "9 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000013240327",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77679,7 +77679,7 @@
     "name": "9 FRANGIPANI AVENUE GLENWOOD 2768",
     "locID": "LOC000096704446",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77695,7 +77695,7 @@
     "name": "9 GALEA DRIVE GLENWOOD 2768",
     "locID": "LOC000064383624",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77711,7 +77711,7 @@
     "name": "9 GARNET GROVE GLENWOOD 2768",
     "locID": "LOC000062050940",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77759,7 +77759,7 @@
     "name": "9 GLENLEA COURT GLENWOOD 2768",
     "locID": "LOC000101629862",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77791,7 +77791,7 @@
     "name": "9 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000028009614",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77807,7 +77807,7 @@
     "name": "9 GOOSEBERRY PLACE GLENWOOD 2768",
     "locID": "LOC000088295773",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77823,7 +77823,7 @@
     "name": "9 GRECH PLACE GLENWOOD 2768",
     "locID": "LOC000080619199",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77869,9 +77869,9 @@
    },
    "properties": {
     "name": "9 HADDON CLOSE GLENWOOD 2768",
-    "locID": "LOC000069847596",
+    "locID": "LOC000012895617",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77887,7 +77887,7 @@
     "name": "9 HAMBRO AVENUE GLENWOOD 2768",
     "locID": "LOC000005449606",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77903,7 +77903,7 @@
     "name": "9 HARCOURT GROVE GLENWOOD 2768",
     "locID": "LOC000019816040",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77935,7 +77935,7 @@
     "name": "9 HIGHCLAIRE PLACE GLENWOOD 2768",
     "locID": "LOC000045382037",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77967,7 +77967,7 @@
     "name": "9 HONEYEATER TERRACE GLENWOOD 2768",
     "locID": "LOC000064426039",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77983,7 +77983,7 @@
     "name": "9 HUNGERFORD DRIVE GLENWOOD 2768",
     "locID": "LOC000065214775",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -77999,7 +77999,7 @@
     "name": "9 IPSWICH AVENUE GLENWOOD 2768",
     "locID": "LOC000003083495",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78015,7 +78015,7 @@
     "name": "9 JEREMY GROVE GLENWOOD 2768",
     "locID": "LOC000122003155",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78047,7 +78047,7 @@
     "name": "9 JOYCE STREET GLENWOOD 2768",
     "locID": "LOC000003086664",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78063,7 +78063,7 @@
     "name": "9 KETURAH CLOSE GLENWOOD 2768",
     "locID": "LOC000089948864",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78095,7 +78095,7 @@
     "name": "9 KINCHEGA CRESCENT GLENWOOD 2768",
     "locID": "LOC000062577374",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78111,7 +78111,7 @@
     "name": "9 KINGSMERE DRIVE GLENWOOD 2768",
     "locID": "LOC000064364898",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78127,7 +78127,7 @@
     "name": "9 KNIGHTSBRIDGE AVENUE GLENWOOD 2768",
     "locID": "LOC000043021043",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78143,7 +78143,7 @@
     "name": "9 KOOKABURRA GROVE GLENWOOD 2768",
     "locID": "LOC000049394879",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78159,7 +78159,7 @@
     "name": "9 KUMQUAT WAY GLENWOOD 2768",
     "locID": "LOC000030492927",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78175,7 +78175,7 @@
     "name": "9 LAURINA WAY GLENWOOD 2768",
     "locID": "LOC000026336166",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78191,7 +78191,7 @@
     "name": "9 LEMON GROVE GLENWOOD 2768",
     "locID": "LOC000061352006",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78223,7 +78223,7 @@
     "name": "9 LORIKEET STREET GLENWOOD 2768",
     "locID": "LOC000044230067",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78239,7 +78239,7 @@
     "name": "9 LYNTON COURT GLENWOOD 2768",
     "locID": "LOC000054437192",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78271,7 +78271,7 @@
     "name": "9 MALVERN ROAD GLENWOOD 2768",
     "locID": "LOC000153932653",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78287,7 +78287,7 @@
     "name": "9 MANDARIN WAY GLENWOOD 2768",
     "locID": "LOC000075454920",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78303,7 +78303,7 @@
     "name": "9 MARS WAY GLENWOOD 2768",
     "locID": "LOC000090230824",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78319,7 +78319,7 @@
     "name": "9 MATARA WAY GLENWOOD 2768",
     "locID": "LOC000077358222",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78335,7 +78335,7 @@
     "name": "9 MATLOCK PLACE GLENWOOD 2768",
     "locID": "LOC000090380786",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78351,7 +78351,7 @@
     "name": "9 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000029642847",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78367,7 +78367,7 @@
     "name": "9 MILPARINKA AVENUE GLENWOOD 2768",
     "locID": "LOC000008103099",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78383,7 +78383,7 @@
     "name": "9 MIMOSA GROVE GLENWOOD 2768",
     "locID": "LOC000041686639",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78399,7 +78399,7 @@
     "name": "9 MINUET COURT GLENWOOD 2768",
     "locID": "LOC000073602980",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78447,7 +78447,7 @@
     "name": "9 MUSCAT GROVE GLENWOOD 2768",
     "locID": "LOC000098375172",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78463,7 +78463,7 @@
     "name": "9 MUSWELLBROOK STREET GLENWOOD 2768",
     "locID": "LOC000103516726",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78495,7 +78495,7 @@
     "name": "9 NIXON STREET GLENWOOD 2768",
     "locID": "LOC000074097648",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78511,7 +78511,7 @@
     "name": "9 NYDEGGAR AVENUE GLENWOOD 2768",
     "locID": "LOC000102172192",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78527,7 +78527,7 @@
     "name": "9 NYMAGEE STREET GLENWOOD 2768",
     "locID": "LOC000040588561",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78559,7 +78559,7 @@
     "name": "9 ORCHARD PLACE GLENWOOD 2768",
     "locID": "LOC000096618241",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78575,7 +78575,7 @@
     "name": "9 PARDALOTE STREET GLENWOOD 2768",
     "locID": "LOC000086092718",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78591,7 +78591,7 @@
     "name": "9 PASSIONFRUIT WAY GLENWOOD 2768",
     "locID": "LOC000102872604",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78607,7 +78607,7 @@
     "name": "9 PEACH GARDENS GLENWOOD 2768",
     "locID": "LOC000030503634",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78623,7 +78623,7 @@
     "name": "9 PEAK STREET GLENWOOD 2768",
     "locID": "LOC000065374329",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78655,7 +78655,7 @@
     "name": "9 PERSIMMON WAY GLENWOOD 2768",
     "locID": "LOC000023727489",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78703,7 +78703,7 @@
     "name": "9 PINNACLE WAY GLENWOOD 2768",
     "locID": "LOC000055764181",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78719,7 +78719,7 @@
     "name": "9 PLUTO COURT GLENWOOD 2768",
     "locID": "LOC000052763532",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78735,7 +78735,7 @@
     "name": "9 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000110216157",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78767,7 +78767,7 @@
     "name": "9 RIDGE STREET GLENWOOD 2768",
     "locID": "LOC000064737812",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78783,7 +78783,7 @@
     "name": "9 ROSELEA STREET GLENWOOD 2768",
     "locID": "LOC000113190040",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78799,7 +78799,7 @@
     "name": "9 RUFUS AVENUE GLENWOOD 2768",
     "locID": "LOC000109814684",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78847,7 +78847,7 @@
     "name": "9 SELINA PLACE GLENWOOD 2768",
     "locID": "LOC000018998696",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78863,7 +78863,7 @@
     "name": "9 SEVILLE PLACE GLENWOOD 2768",
     "locID": "LOC000023748321",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78879,7 +78879,7 @@
     "name": "9 SHARROCK AVENUE GLENWOOD 2768",
     "locID": "LOC000079772686",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78895,7 +78895,7 @@
     "name": "9 SHAUN STREET GLENWOOD 2768",
     "locID": "LOC000065419112",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78959,7 +78959,7 @@
     "name": "9 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000038027945",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78975,7 +78975,7 @@
     "name": "9 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000087000103",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -78991,7 +78991,7 @@
     "name": "9 STAFF AVENUE GLENWOOD 2768",
     "locID": "LOC000093792133",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79023,7 +79023,7 @@
     "name": "9 STRAWBERRY WAY GLENWOOD 2768",
     "locID": "LOC000070165832",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79039,7 +79039,7 @@
     "name": "9 SULTANA GROVE GLENWOOD 2768",
     "locID": "LOC000002428085",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79055,7 +79055,7 @@
     "name": "9 SUMMIT COURT GLENWOOD 2768",
     "locID": "LOC000021293379",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79087,7 +79087,7 @@
     "name": "9 TARWIN AVENUE GLENWOOD 2768",
     "locID": "LOC000064944671",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79103,7 +79103,7 @@
     "name": "9 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000079905608",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79119,7 +79119,7 @@
     "name": "9 VALIS ROAD GLENWOOD 2768",
     "locID": "LOC000066545758",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79135,7 +79135,7 @@
     "name": "9 VANESSA COURT GLENWOOD 2768",
     "locID": "LOC000054076703",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79151,7 +79151,7 @@
     "name": "9 WALTHAM WAY GLENWOOD 2768",
     "locID": "LOC000075850660",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79167,7 +79167,7 @@
     "name": "9 WANAARING TERRACE GLENWOOD 2768",
     "locID": "LOC000086401706",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79199,7 +79199,7 @@
     "name": "9 WATTLEBIRD PLACE GLENWOOD 2768",
     "locID": "LOC000086848840",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79215,7 +79215,7 @@
     "name": "9 WENDY PLACE GLENWOOD 2768",
     "locID": "LOC000022143595",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79231,7 +79231,7 @@
     "name": "9 WHEEDON STREET GLENWOOD 2768",
     "locID": "LOC000097898924",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79247,7 +79247,7 @@
     "name": "9 WHIBLEY AVENUE GLENWOOD 2768",
     "locID": "LOC000048097149",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79263,7 +79263,7 @@
     "name": "9 WILLOWLEAF CLOSE GLENWOOD 2768",
     "locID": "LOC000052780916",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79279,7 +79279,7 @@
     "name": "9 YANCANNIA TERRACE GLENWOOD 2768",
     "locID": "LOC000041112800",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79295,7 +79295,7 @@
     "name": "90 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000067571457",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79311,7 +79311,7 @@
     "name": "90 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000057327945",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79327,7 +79327,7 @@
     "name": "90 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000104183054",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79359,7 +79359,7 @@
     "name": "90 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000060190847",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79391,7 +79391,7 @@
     "name": "91 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000051563725",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79439,7 +79439,7 @@
     "name": "91 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000023320072",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79455,7 +79455,7 @@
     "name": "91A THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000023320072",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79471,7 +79471,7 @@
     "name": "91B THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000022916018",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79487,7 +79487,7 @@
     "name": "92 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000049302742",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79503,7 +79503,7 @@
     "name": "92 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000046914169",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79535,7 +79535,7 @@
     "name": "92 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000089439547",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79551,7 +79551,7 @@
     "name": "92A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000153952302",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79567,7 +79567,7 @@
     "name": "92B MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC100081098522",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79599,7 +79599,7 @@
     "name": "93 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000005044178",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79615,7 +79615,7 @@
     "name": "93 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000104150525",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79647,7 +79647,7 @@
     "name": "93A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000099958963",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79663,7 +79663,7 @@
     "name": "93B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000099725009",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79679,7 +79679,7 @@
     "name": "94 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000015012789",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79695,7 +79695,7 @@
     "name": "94 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000060884249",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79727,7 +79727,7 @@
     "name": "94 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000007354003",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79743,7 +79743,7 @@
     "name": "94A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000176353092",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79775,7 +79775,7 @@
     "name": "95 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000053730551",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79791,7 +79791,7 @@
     "name": "95 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000020543007",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79807,7 +79807,7 @@
     "name": "95A GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000053933158",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79823,7 +79823,7 @@
     "name": "95B GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000053730551",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79839,7 +79839,7 @@
     "name": "96 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000069234762",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79869,7 +79869,7 @@
    },
    "properties": {
     "name": "96 MEURANTS LANE GLENWOOD 2768",
-    "locID": "LOC000153952704",
+    "locID": "LOC000153952727",
     "tech": "FTTN",
     "upgrade": "NULL_NA"
    }
@@ -79887,7 +79887,7 @@
     "name": "97 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000020962571",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79903,7 +79903,7 @@
     "name": "98 FORMAN AVENUE GLENWOOD 2768",
     "locID": "LOC000003205700",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79919,7 +79919,7 @@
     "name": "98 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000022280200",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79951,7 +79951,7 @@
     "name": "98 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000089234044",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79967,7 +79967,7 @@
     "name": "98A MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC100055121053",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79983,7 +79983,7 @@
     "name": "98B MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC100055121069",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -79999,7 +79999,7 @@
     "name": "99 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000080113361",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80015,7 +80015,7 @@
     "name": "99 MEURANTS LANE GLENWOOD 2768",
     "locID": "LOC000075594833",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80031,7 +80031,7 @@
     "name": "992 OLD WINDSOR ROAD GLENWOOD 2768",
     "locID": "LOC000037900996",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80079,7 +80079,7 @@
     "name": "HOUSE 1, 14 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000115545538",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80095,7 +80095,7 @@
     "name": "HOUSE 2, 14 SORRENTO DRIVE GLENWOOD 2768",
     "locID": "LOC000115545538",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80111,7 +80111,7 @@
     "name": "SHOP 1, 174 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000069423228",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80319,7 +80319,7 @@
     "name": "UNIT 1, 12 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000102555172",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80335,7 +80335,7 @@
     "name": "UNIT 1, 125 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000048094850",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80383,7 +80383,7 @@
     "name": "UNIT 1, 147 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000099727126",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80399,7 +80399,7 @@
     "name": "UNIT 1, 148 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000078684000",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80447,7 +80447,7 @@
     "name": "UNIT 1, 2 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000092041400",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80463,7 +80463,7 @@
     "name": "UNIT 1, 2 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000085233846",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80543,7 +80543,7 @@
     "name": "UNIT 1, 5 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000089414464",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80559,7 +80559,7 @@
     "name": "UNIT 1, 52 CASINO STREET GLENWOOD 2768",
     "locID": "LOC000003297719",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80575,7 +80575,7 @@
     "name": "UNIT 1, 6 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000036278596",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80591,7 +80591,7 @@
     "name": "UNIT 1, 91 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000023320072",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80607,7 +80607,7 @@
     "name": "UNIT 1, 94 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000060884249",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80863,7 +80863,7 @@
     "name": "UNIT 2, 12 DAIRY COURT GLENWOOD 2768",
     "locID": "LOC000102555172",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80879,7 +80879,7 @@
     "name": "UNIT 2, 125 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000048094850",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80927,7 +80927,7 @@
     "name": "UNIT 2, 147 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000099727126",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80943,7 +80943,7 @@
     "name": "UNIT 2, 148 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000078684000",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -80991,7 +80991,7 @@
     "name": "UNIT 2, 2 BURNHAM AVENUE GLENWOOD 2768",
     "locID": "LOC000092041400",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -81007,7 +81007,7 @@
     "name": "UNIT 2, 2 SOUTHWAITE CRESCENT GLENWOOD 2768",
     "locID": "LOC000085233846",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -81087,7 +81087,7 @@
     "name": "UNIT 2, 5 POMEGRANATE PLACE GLENWOOD 2768",
     "locID": "LOC000089579540",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -81103,7 +81103,7 @@
     "name": "UNIT 2, 91 THOMPSON CRESCENT GLENWOOD 2768",
     "locID": "LOC000023320072",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -81119,7 +81119,7 @@
     "name": "UNIT 2, 94 GLENWOOD PARK DRIVE GLENWOOD 2768",
     "locID": "LOC000060884249",
     "tech": "FTTN",
-    "upgrade": "NULL_NA"
+    "upgrade": "FTTP_NA"
    }
   },
   {
@@ -81133,7 +81133,7 @@
    },
    "properties": {
     "name": "UNIT 2, 96 MEURANTS LANE GLENWOOD 2768",
-    "locID": "LOC000153952704",
+    "locID": "LOC000153952727",
     "tech": "FTTN",
     "upgrade": "NULL_NA"
    }
@@ -81789,7 +81789,7 @@
    },
    "properties": {
     "name": "UNIT 6, 4-6 BOONDEROO AVENUE GLENWOOD 2768",
-    "locID": "LOC000153914682",
+    "locID": "LOC000153916123",
     "tech": "FTTN",
     "upgrade": "NULL_NA"
    }


### PR DESCRIPTION
Per https://github.com/LukePrior/nbn-upgrade-map/issues/97

The FTTP_NA addresses aren't being handled by the current map code:

fillColor: feature.properties.upgrade == "FTTP_SA" ? "#00ff00" : feature.properties.tech == "FTTP" ? "#00aa00" : feature.properties.tech == "HFC" ? "#ffa500" : feature.properties.upgrade == "UNKNOWN" ? "#888888" : "#ff0000",
