### PR TITLE
Update DB to postgres 16, reduce image size, simplify Dockerfile

### DIFF
--- a/extra/db/20_import_csv.sh
+++ b/extra/db/20_import_csv.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x
+
+psql -a -c "CREATE SCHEMA gnaf_cutdown"
+
+psql -a -f /data/create-table.sql
+
+gunzip -c /data/address_principals.csv.gz | psql -c 'COPY gnaf_cutdown.address_principals FROM stdin WITH CSV HEADER'
+
+

--- a/extra/db/20_import_gnaf.sh
+++ b/extra/db/20_import_gnaf.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -x
+
+pg_restore -v -Fc -d postgres --schema-only /data/gnaf-$GNAF_LOADER_TAG.dmp
+
+pg_restore -v -Fc -d postgres --data-only -t address_principals --disable-triggers /data/gnaf-$GNAF_LOADER_TAG.dmp
+
+psql -c "copy (SELECT gnaf_pid, address, locality_name, postcode, state, latitude, longitude FROM gnaf_${GNAF_LOADER_TAG}.address_principals) to stdout with CSV HEADER;" | gzip -9 > /tmp/address_principals.csv.gz
+
+echo "Exported CSV..."
+ls -l /tmp/address_principals.csv.gz

--- a/extra/db/Dockerfile
+++ b/extra/db/Dockerfile
@@ -1,107 +1,38 @@
-########################################################################
-# data-extraction stage
-FROM debian:buster-slim
+# STAGE 1: import the DB dump files then export a cutdown CSV file
+FROM postgis/postgis:15-3.4-alpine
+ENV POSTGRES_HOST_AUTH_METHOD=trust
 
-# Postgres user password - WARNING: change this to something a lot more secure
-ARG pg_password="password"
-ENV PGPASSWORD=${pg_password}
-
-# get postgres signing key, add Postgres repo to apt and install Postgres with PostGIS
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get install -y sudo wget gnupg2 \
-    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - \
-    && echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" | sudo tee  /etc/apt/sources.list.d/pgdg.list \
-    && apt-get update \
-    && apt-get install -y postgresql-15 postgresql-client-15 postgis postgresql-15-postgis-3 \
-    && apt-get autoremove -y --purge \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# start Postgres server and set the default user password
-RUN /etc/init.d/postgresql start \
-    && sudo -u postgres psql -c "ALTER USER postgres PASSWORD '${pg_password}';" \
-    && sudo -u postgres psql -c "CREATE EXTENSION postgis;" \
-    && /etc/init.d/postgresql stop
-
-# enable external access to postgres - WARNING: these are insecure settings! Edit these to restrict access
-RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/15/main/pg_hba.conf
-RUN echo "listen_addresses='*'" >> /etc/postgresql/15/main/postgresql.conf
-
-# download and restore GNAF & Admin Boundary Postgres dump files
 RUN mkdir -p /data
 WORKDIR /data
 
 ARG GNAF_LOADER_TAG="latest"
-
 ADD gnaf-${GNAF_LOADER_TAG}.dmp .
 
-RUN /etc/init.d/postgresql start \
-    && pg_restore -v -Fc -d postgres -h localhost -p 5432 -U postgres --schema-only /data/gnaf-$GNAF_LOADER_TAG.dmp \
-    && pg_restore -v -Fc -d postgres -h localhost -p 5432 -U postgres --data-only -t address_principals --disable-triggers /data/gnaf-$GNAF_LOADER_TAG.dmp \
-    && /etc/init.d/postgresql stop \
-    && rm /data/gnaf-$GNAF_LOADER_TAG.dmp
+ADD 20_import_gnaf.sh /docker-entrypoint-initdb.d/20_import_gnaf.sh
 
-EXPOSE 5432
-
-# set user for postgres startup
-USER postgres
-
-RUN /etc/init.d/postgresql start \
-    && psql -c "copy (SELECT gnaf_pid, address, locality_name, postcode, state, latitude, longitude FROM gnaf_${GNAF_LOADER_TAG}.address_principals) to stdout with CSV HEADER;" | gzip -9 > /tmp/address_principals.csv.gz \
-    && /etc/init.d/postgresql stop
-
-# Start postgres when starting the container
-CMD ["/usr/lib/postgresql/15/bin/postgres", "-D", "/var/lib/postgresql/15/main", "-c", "config_file=/etc/postgresql/15/main/postgresql.conf"]
+# need postgres to exit after running the script, so we can run the next script
+RUN sed -i 's/exec "$@"/#exec "$@"/' /usr/local/bin/docker-entrypoint.sh
+RUN bash -x /usr/local/bin/docker-entrypoint.sh postgres
 
 
-########################################################################
-# minimal DB stage
+# STAGE 2: load the CSV file from previous stage into right DB version (no PostGIS)
+FROM postgres:16-alpine
+ENV POSTGRES_HOST_AUTH_METHOD=trust
 
-FROM debian:buster-slim
-
-# Postgres user password - WARNING: change this to something a lot more secure
-ARG pg_password="password"
-ENV PGPASSWORD=${pg_password}
-
-# get postgres signing key, add Postgres repo to apt and install Postgres with PostGIS
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get install -y sudo wget gnupg2 \
-    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - \
-    && echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" | sudo tee  /etc/apt/sources.list.d/pgdg.list \
-    && apt-get update \
-    && apt-get install -y postgresql-15 postgresql-client-15 postgis postgresql-15-postgis-3 \
-    && apt-get autoremove -y --purge \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# start Postgres server and set the default user password
-RUN /etc/init.d/postgresql start \
-    && sudo -u postgres psql -c "ALTER USER postgres PASSWORD '${pg_password}';" \
-    && sudo -u postgres psql -c "CREATE EXTENSION postgis;" \
-    && /etc/init.d/postgresql stop
-
-# enable external access to postgres - WARNING: these are insecure settings! Edit these to restrict access
-RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/15/main/pg_hba.conf
-RUN echo "listen_addresses='*'" >> /etc/postgresql/15/main/postgresql.conf
-
-# download and restore SQL schema and previously exported table data
-RUN mkdir -m a+w -p /data
+RUN mkdir -p /data
 WORKDIR /data
-
-EXPOSE 5432
-
-ADD --chown=postgres create-table.sql /data/
 COPY --from=0 --chown=postgres /tmp/address_principals.csv.gz /data/
+ADD --chown=postgres create-table.sql /data/
+ADD 20_import_csv.sh /docker-entrypoint-initdb.d/
 
-# set user for postgres startup
-USER postgres
+# need postgres to exit after running the script, so we can run the next script
+RUN sed -i 's/exec "$@"/#exec "$@"/' /usr/local/bin/docker-entrypoint.sh
+RUN bash -x /usr/local/bin/docker-entrypoint.sh postgres
 
-RUN /etc/init.d/postgresql start \
-    && psql -a -c "CREATE SCHEMA gnaf_cutdown" \
-    && psql -a -f create-table.sql \
-    && gunzip -c address_principals.csv.gz | psql -c 'COPY gnaf_cutdown.address_principals FROM stdin WITH CSV HEADER' \
-    && /etc/init.d/postgresql stop \
-    && rm -v create-table.sql address_principals.csv.gz
 
-# Start postgres when starting the container
-CMD ["/usr/lib/postgresql/15/bin/postgres", "-D", "/var/lib/postgresql/15/main", "-c", "config_file=/etc/postgresql/15/main/postgresql.conf"]
+# STAGE 3: just use the data from the previous stage
+FROM postgres:16-alpine
+ENV POSTGRES_USER=postgres
+ENV POSTGRES_PASSWORD=password
+
+COPY --from=1 --chown=postgres /var/lib/postgresql/data /var/lib/postgresql/data

--- a/extra/db/Dockerfile
+++ b/extra/db/Dockerfile
@@ -1,5 +1,5 @@
 # STAGE 1: import the DB dump files then export a cutdown CSV file
-FROM postgis/postgis:15-3.4-alpine
+FROM postgis/postgis:16-3.4-alpine
 ENV POSTGRES_HOST_AUTH_METHOD=trust
 
 RUN mkdir -p /data


### PR DESCRIPTION
Use three stages for DB build:
1. Import the DB dump into a postgis DB; export CSV
2. Import the CSV into a postgres:16-alpine DB
3. Copy DB files from stage 2

DB image now ~3.01GB and newer version (with much shorter Dockerfile)