### PR TITLE
When creating sqlite DB, create index _after_ importing the data

### DIFF
--- a/extra/db/docker2sqlite.sh
+++ b/extra/db/docker2sqlite.sh
@@ -32,10 +32,11 @@ else
     longitude numeric(11,8) NOT NULL
   );
 
-  CREATE INDEX address_name_state ON address_principals(locality_name, state);
-
 .mode csv
 .import $CSV_FILENAME address_principals
+
+  CREATE INDEX address_name_state ON address_principals(locality_name, state);
+
 .exit
 EOF
 


### PR DESCRIPTION
Less fragmented? Faster?  (2.7% smaller anyway)