### PR TITLE
Update GHA versions to fix Node 16 deprecation warnings:

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -1,5 +1,5 @@
 name: Suburb Automatic
-on: 
+on:
   workflow_dispatch:
   repository_dispatch:
     types: [auto-suburb]
@@ -13,7 +13,7 @@ jobs:
         shell: bash
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         sparse-checkout-cone-mode: false
         sparse-checkout: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: Suburb Check
-on: 
+on:
   workflow_dispatch:
     inputs:
       suburb:
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker
         run: |

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           sparse-checkout-cone-mode: false

--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
@@ -21,14 +21,14 @@ jobs:
             !results
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: lukeprior/nbn-upgrade-map
           tags: |
@@ -36,7 +36,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./
           push: true

--- a/.github/workflows/publish-db-image.yml
+++ b/.github/workflows/publish-db-image.yml
@@ -18,7 +18,7 @@ jobs:
           remove-codeql: 'true'
 
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
@@ -26,7 +26,7 @@ jobs:
             !results
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: lukeprior/nbn-upgrade-map-db
           tags: |
@@ -53,7 +53,7 @@ jobs:
           curl --insecure https://minus34.com/opendata/geoscape-$GNAF_LOADER_TAG/gnaf-$GNAF_LOADER_TAG.dmp --output ./extra/db/gnaf-$GNAF_LOADER_TAG.dmp
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./extra/db
           push: true
@@ -71,7 +71,7 @@ jobs:
         run: ./extra/db/docker2sqlite.sh
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: sqlite-db-${{ steps.version.outputs.GNAF_LOADER_TAG }}
           body: SQLite DB for the cutdown version of the GNAF address database

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           sparse-checkout: 'site'
       - name: Setup Pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |

--- a/.github/workflows/update-breakdown.yml
+++ b/.github/workflows/update-breakdown.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v3


### PR DESCRIPTION
https://github.com/actions/checkout to v4
https://github.com/docker/login-action to v3
https://github.com/docker/metadata-action to v5
https://github.com/docker/build-push-action to v5
https://github.com/softprops/action-gh-release to v2

Per https://github.com/LukePrior/nbn-upgrade-map/issues/343
