### PR TITLE
Add adhoc tool for generating a local site

### DIFF
--- a/code/adhoc_tools.py
+++ b/code/adhoc_tools.py
@@ -399,6 +399,38 @@ def dump_status_tech_upgrade():
     pprint.pprint(tallies)
 
 
+def generate_local_website():
+    """Generate a version of the website with all data local."""
+    # copy index.html -> index-local.html
+    with open("./site/index.html") as f:
+        index_html = f.read().replace('main.js', 'main-local.js')
+        with open("./site/index-local.html", "w") as f:
+            f.write(index_html)
+
+    # copy main.js -> main-local.js
+    with open("./site/main.js") as f:
+        gh_prefix = 'https://raw.githubusercontent.com/LukePrior/nbn-upgrade-map'
+        main_js = (f.read()
+                   # use local results files
+                   .replace(gh_prefix + '/main/results', '../results')
+                   .replace(gh_prefix + '/" + commit + "/results', '../results')
+                   # disable serviceworkerr
+                   .replace('navigator.serviceWorker.', '// ')
+                   # disable date selector
+                   .replace("addControlWithHTML('date-selector'", '// ')
+                   .replace('fetch(commits_url)', 'new Promise( () => {} )')
+                   # disable gtagr
+                   .replace('gtag(', '// gtag(')
+                   )
+
+        with open("./site/main-local.js", "w") as f:
+            f.write(main_js)
+
+    # to view this locally, start a simple web-server with the following command (from the top level directory):
+    #     python -m http.server 8000
+    # and open http://localhost:8000/index-local.html
+
+
 if __name__ == "__main__":
     LOGLEVEL = os.environ.get("LOGLEVEL", "INFO").upper()
     logging.basicConfig(level=LOGLEVEL, format="%(asctime)s %(levelname)s %(threadName)s %(message)s")

--- a/code/adhoc_tools.py
+++ b/code/adhoc_tools.py
@@ -403,25 +403,26 @@ def generate_local_website():
     """Generate a version of the website with all data local."""
     # copy index.html -> index-local.html
     with open("./site/index.html") as f:
-        index_html = f.read().replace('main.js', 'main-local.js')
+        index_html = f.read().replace("main.js", "main-local.js")
         with open("./site/index-local.html", "w") as f:
             f.write(index_html)
 
     # copy main.js -> main-local.js
     with open("./site/main.js") as f:
-        gh_prefix = 'https://raw.githubusercontent.com/LukePrior/nbn-upgrade-map'
-        main_js = (f.read()
-                   # use local results files
-                   .replace(gh_prefix + '/main/results', '../results')
-                   .replace(gh_prefix + '/" + commit + "/results', '../results')
-                   # disable serviceworkerr
-                   .replace('navigator.serviceWorker.', '// ')
-                   # disable date selector
-                   .replace("addControlWithHTML('date-selector'", '// ')
-                   .replace('fetch(commits_url)', 'new Promise( () => {} )')
-                   # disable gtagr
-                   .replace('gtag(', '// gtag(')
-                   )
+        gh_prefix = "https://raw.githubusercontent.com/LukePrior/nbn-upgrade-map"
+        main_js = (
+            f.read()
+            # use local results files
+            .replace(gh_prefix + "/main/results", "../results")
+            .replace(gh_prefix + '/" + commit + "/results', "../results")
+            # disable serviceworkerr
+            .replace("navigator.serviceWorker.", "// ")
+            # disable date selector
+            .replace("addControlWithHTML('date-selector'", "// ")
+            .replace("fetch(commits_url)", "new Promise( () => {} )")
+            # disable gtagr
+            .replace("gtag(", "// gtag(")
+        )
 
         with open("./site/main-local.js", "w") as f:
             f.write(main_js)

--- a/code/adhoc_tools.py
+++ b/code/adhoc_tools.py
@@ -429,7 +429,7 @@ def generate_local_website():
 
     # to view this locally, start a simple web-server with the following command (from the top level directory):
     #     python -m http.server 8000
-    # and open http://localhost:8000/index-local.html
+    # and open http://localhost:8000/site/index-local.html
 
 
 if __name__ == "__main__":

--- a/code/adhoc_tools.py
+++ b/code/adhoc_tools.py
@@ -420,7 +420,7 @@ def generate_local_website():
             # disable date selector
             .replace("addControlWithHTML('date-selector'", "// ")
             .replace("fetch(commits_url)", "new Promise( () => {} )")
-            # disable gtagr
+            # disable gtags
             .replace("gtag(", "// gtag(")
         )
 


### PR DESCRIPTION
Per #379 this is a script to generate a local-only version of the website.

To use it, using a local webserver, rather than dealing with CORS issues with file:// , you can:

- `./code/adhoc_tools.py generate_local_website`
- `python -m http.server 8000`
- open http://localhost:8000/site/index-local.html

PS: of course, the map-tiles still come from the web

If you really want to run with file:// and not a local webserver, you will need to open your browser with something like

```
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome  \
   --disable-web-security --user-data-dir=$PWD/xxx site/index-local.html
```

This will create a local directory "xxx" and store your chrome user-data in there. You can't use your main/default user data.

<img width="1408" alt="image" src="https://github.com/LukePrior/nbn-upgrade-map/assets/122371/474057fe-fb82-46d6-a4c9-2f273bfdb926">
