### PR TITLE
Show correct icon for sites upgraded but previous tech not yet disconnected

### DIFF
--- a/site/main.js
+++ b/site/main.js
@@ -184,8 +184,13 @@ function getDotType(tech, upgrade, date, status, generated) {
         return dotTypes.FTTP;
     }
 
-    // Eligible for immediate upgrade
+    // Upgraded to FTTP but previous tech not yet disconnected
     upgrade_type = upgrade.split("_")[0]
+    if (status == "New Tech Connected" && upgrade_type == "FTTP") {
+        return dotTypes.FTTP;
+    }
+
+    // Eligible for immediate upgrade
     if (status == "Eligible To Order" || status == "Eligible to Order") {
         return (upgrade_type == "FTTP") ? dotTypes.FTTPUpgrade : dotTypes.OtherUpgrade;
     }


### PR DESCRIPTION
I think this should resolve #384

Something to note is this issue seems to apply to addresses which the NBN autocompletion API has as being "lots" I doubt this is a coincidence.