### PR TITLE
Disable docker2sqlite DB step

### DIFF
--- a/.github/workflows/publish-db-image.yml
+++ b/.github/workflows/publish-db-image.yml
@@ -62,17 +62,17 @@ jobs:
           build-args: |
             GNAF_LOADER_TAG=${{ steps.version.outputs.GNAF_LOADER_TAG }}
 
-      - name: Remove GNAF data dmp
-        run: |
-          GNAF_LOADER_TAG=${{ steps.version.outputs.GNAF_LOADER_TAG }}
-          rm -fv ./extra/db/gnaf-$GNAF_LOADER_TAG.dmp
+      # - name: Remove GNAF data dmp
+      #   run: |
+      #     GNAF_LOADER_TAG=${{ steps.version.outputs.GNAF_LOADER_TAG }}
+      #     rm -fv ./extra/db/gnaf-$GNAF_LOADER_TAG.dmp
 
-      - name: Convert the Postgres DB to SQLite
-        run: ./extra/db/docker2sqlite.sh
+      # - name: Convert the Postgres DB to SQLite
+      #   run: ./extra/db/docker2sqlite.sh
 
-      - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: sqlite-db-${{ steps.version.outputs.GNAF_LOADER_TAG }}
-          body: SQLite DB for the cutdown version of the GNAF address database
-          files: address_principals.sqlite
+      # - name: Release
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     tag_name: sqlite-db-${{ steps.version.outputs.GNAF_LOADER_TAG }}
+      #     body: SQLite DB for the cutdown version of the GNAF address database
+      #     files: address_principals.sqlite


### PR DESCRIPTION
It's currently failing due to lack of space in GHA runner. See https://github.com/LukePrior/nbn-upgrade-map/issues/370