### PR TITLE
Disable indent for `breakdown-suburbs.json`

### DIFF
--- a/code/adhoc_tools.py
+++ b/code/adhoc_tools.py
@@ -227,7 +227,7 @@ def update_historical_tech_and_upgrade_breakdown():
             breakdowns[date_key] = get_tech_and_upgrade_breakdown(checkout_dir)
             breakdown_suburbs[date_key] = breakdowns[date_key].pop("suburb_tech")
             utils.write_json_file(breakdown_file, breakdowns)  # save each time
-            utils.write_json_file(breakdown_suburbs_file, breakdown_suburbs)  # save each time
+            utils.write_json_file(breakdown_suburbs_file, breakdown_suburbs, indent=None)  # save each time
         co_date += timedelta(days=7)
 
     # print tech+upgrade breakdown
@@ -331,7 +331,7 @@ def fix_fw_tech_type_breakdowns():
         for state, suburb_list in date_info.items():
             for suburb, breakdown in suburb_list.items():
                 fix_tech_breakdown(breakdown)
-    utils.write_json_file("results/breakdown-suburbs.json", breakdowns)
+    utils.write_json_file("results/breakdown-suburbs.json", breakdowns, indent=None)
 
     # breakdown-state.json and breakdown.STATE.csv (uses breakdown-suburbs.json)
     generate_state_breakdown()
@@ -378,7 +378,7 @@ def update_breakdown():
         breakdowns[date_key] = get_tech_and_upgrade_breakdown()
         breakdown_suburbs[date_key] = breakdowns[date_key].pop("suburb_tech")
         utils.write_json_file(breakdown_file, breakdowns)
-        utils.write_json_file(breakdown_suburbs_file, breakdown_suburbs)
+        utils.write_json_file(breakdown_suburbs_file, breakdown_suburbs, indent=None)
 
     return breakdowns
 


### PR DESCRIPTION
Disables the indentation in `breakdown-suburbs.json`

This reduces its file size from ~99MB to ~45MB, the maximum size for a file on github is 100MB.

Currently, the [workflow](https://github.com/LukePrior/nbn-upgrade-map/actions/runs/14850473112) for updating the breakdown on `/stats` is failing due to this file growing larger than 100MB. 

Further work could be done here to reduce the file size, such as providing a custom set of `seperators`, but this provides heaps of headroom under the maximum file size as-is.

I can also commit the updated jsons if you would like.