### PR TITLE
Update main.js (Change dot colours for contrast)

### DIFF
--- a/site/main.js
+++ b/site/main.js
@@ -152,15 +152,15 @@ $(document).ready(function() {
 const dotTypes = {
     FTTP: {
         label: 'FTTP',
-        colour: '#1D7044'
+        colour: '#149300'
     },
     FTTPUpgrade: {
         label: 'FTTP Upgrade',
-        colour: '#75AD6F'
+        colour: '#22FF00'
     },
     FTTPUpgradeSoon: {
         label: 'FTTP Upgrade Soon',
-        colour: '#C8E3C5'
+        colour: '#C1FFBA'
     },
     OtherUpgrade: {
         label: 'Other Upgrade',
@@ -172,23 +172,23 @@ const dotTypes = {
     },
     HFC: {
         label: 'HFC',
-        colour: '#FFBE00',
+        colour: '#F4FF57',
     },
     FTTC: {
         label: 'FTTC',
-        colour: '#FF7E01'
+        colour: '#FF45C7'
     },
     FTTN_FTTB: {
         label: 'FTTN/FTTB',
-        colour: '#E3071D'
+        colour: '#FF001A'
     },
     WirelessSat: {
         label: 'FW/SAT',
-        colour: '#C91414'
+        colour: '#FFFFFF'
     },
     Unknown: {
         label: 'Unknown',
-        colour: '#888888'
+        colour: '#333333'
     },
 };
 


### PR DESCRIPTION
New colour palette for dots to add greater contrast and less overlap of colours, hopefully increasing visual contrast for colour-vision-impaired users.

Stuck with existing colour-scheme for the most part, removing some of the red-orange colours and making the "FTTP upgrade available" colour significantly lighter than the most common technologies being moved over (FTTN and FTTC)).

Colours viewable here, click on the hex code to see the colour in a small icon for better representation:
https://coolors.co/149300-22ff00-c1ffba-4464ad-44c5e3-f4ff57-ff45c7-ff001a-ffffff-333333